### PR TITLE
docs: pin PG 18 + Cloudflare DNS/SSL

### DIFF
--- a/.samo/SPEC.amendments.md
+++ b/.samo/SPEC.amendments.md
@@ -41,6 +41,36 @@ one migration tool, one queue, one provider). Keeps things simple per the
 
 ---
 
+## 2026-05-02 — Postgres 18 pin + Cloudflare for DNS/SSL
+
+**Spec section affected:** §Architecture, §Implementation Plan / Sprint 3
+self-host story.
+
+**Amendment:**
+
+- **Postgres 18** pinned for v0.1. (Spec was silent on PG version.) sqlever
+  static-analysis rules and any PG-version-sensitive SQL must target 18.
+  pgque already supports PG 14+; pg_ash compatibility is not required for
+  v0.1.
+- **Cloudflare** is the documented DNS + SSL termination layer for the
+  self-host story. Self-host docs cover: DNS A/AAAA records, "Full (strict)"
+  SSL with origin certs, and optional Cloudflare Tunnel for home servers
+  that don't have a public IP. Caddy/nginx is no longer required as a
+  default reverse proxy in the self-host quickstart (Cloudflare proxy +
+  Bun's built-in HTTP server is enough); Caddy remains an option for users
+  not using Cloudflare.
+- **Latest-stable rule:** all third-party deps (Bun, Next.js, Luxon, etc.)
+  pinned to latest stable at Sprint 0 lock-in. The spec's deferred
+  Temporal-migration item still holds.
+
+**Rationale:** Maintainer's hosting setup. Cloudflare is "free SSL +
+free DNS + DDoS-shielded" which fits the self-host story; PG 18 is the
+current stable line at project start.
+
+**Decided by:** maintainer (NikolayS) on 2026-05-02.
+
+---
+
 ## 2026-05-02 — Auth model: admin-only login, anonymous booking
 
 **Spec section affected:** §Tests Plan / Security (Admin UI auth), §Tenancy.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,23 +11,34 @@ durable email outbox. See `.samo/SPEC.md` for the full v0.2 spec.
 **These choices OVERRIDE the SPEC where they conflict.** See
 `.samo/SPEC.amendments.md` for the audit trail.
 
-- **Runtime:** TypeScript on **Bun** (test runner, scripts, server)
-- **Web framework:** **Next.js** (per spec — SSR public booking pages)
+- **Runtime:** TypeScript on **Bun** — latest stable. Bun runs the test
+  runner, scripts, and the worker process.
+- **Web framework:** **Next.js** — latest stable (per spec — SSR public
+  booking pages).
 - **Database + auth:** **self-hosted Supabase** (compose-based; no Supabase
-  Cloud dependency). Postgres for data; GoTrue for admin auth.
-- **Admin auth:** magic link (via **Resend**) + **Google OAuth**.
-  Bookers (public visitors) DO NOT log in — booking page is anonymous and
-  uses signed links for cancel/reschedule.
+  Cloud dependency). **Postgres 18** pinned. Supabase GoTrue handles admin
+  auth.
+- **Admin auth:** **magic link** + **Google OAuth** (via Supabase GoTrue;
+  magic-link emails sent via Resend). Bookers (public visitors) DO NOT
+  log in — public booking page is anonymous; cancel/reschedule is gated
+  by signed links sent in confirmation email.
 - **Migrations:** **sqlever** (https://github.com/NikolayS/sqlever) — Sqitch-
   compatible with built-in static analysis. `deploy/`, `revert/`, `verify/`
   scripts plus `sqitch.plan`.
-- **Time:** **Luxon** (per spec — DST gap/fold semantics locked into fixtures)
+- **Time:** **Luxon** — latest stable (per spec — DST gap/fold semantics
+  locked into fixtures).
 - **Queues:** **pgque** (https://github.com/NikolayS/pgque) — install via
-  `\i pgque.sql`; pg_cron drives the ticker
+  `\i pgque.sql`; pg_cron drives the ticker.
 - **Email:** **Resend** (transactional) for booking confirmations, reminders,
-  conflict notifications, magic links. Generic SMTP fallback documented for
-  self-hosters who don't want Resend.
-- **External:** Google Calendar API (OAuth + watch channels + sync tokens)
+  conflict notifications, and magic-link auth.
+- **DNS + SSL:** **Cloudflare** — DNS, TLS termination/origin certs, and
+  proxying for the public booking page and admin UI. Self-host docs include
+  the Cloudflare setup (DNS records, SSL mode, optional Tunnel for home
+  servers).
+- **External:** Google Calendar API (OAuth + watch channels + sync tokens).
+
+**General rule:** all third-party libraries pinned to **latest stable** at
+Sprint 0 lock-in. No legacy support targets unless a SPEC fixture requires it.
 
 ## Keep it simple
 


### PR DESCRIPTION
## Summary

Tightens the stack list before Sprint 0 dispatch:
- Postgres **18** pinned (spec was silent)
- Cloudflare for DNS + SSL termination — Caddy demoted from default to optional in self-host quickstart
- General "latest stable" rule for third-party deps

Manager fast-track again — CI not wired yet (Sprint 0 deliverable). Audit trail in `.samo/SPEC.amendments.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VS1pxnCA4d6mHKDFcejm6T)_