### PR TITLE
chore: add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,31 @@
+# Claude Code agent isolation worktrees (auto-created, never committed)
+.claude/
+
+# Env / secrets
+.env
+.env.local
+.env.*.local
+
+# Editor
+.vscode/
+.idea/
+*.swp
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Bun / Node
+node_modules/
+.next/
+.turbo/
+dist/
+build/
+coverage/
+*.tsbuildinfo
+bun.lockb.bak
+
+# Test artifacts
+/playwright-report/
+/test-results/
+.k6-summary.json


### PR DESCRIPTION
## Summary

Adds `.gitignore`. Notably ignores `.claude/` (Claude Code agent isolation worktrees auto-created by the Agent tool — must never be committed), plus standard env/build/editor entries.

Manager fast-track — CI not wired yet.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VS1pxnCA4d6mHKDFcejm6T)_