### PR TITLE
[Sprint 0/Scheduling] slot-gen pure functions + 8 invariants (#7)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4,9 +4,14 @@
   "workspaces": {
     "": {
       "name": "calendry2",
+      "dependencies": {
+        "fast-check": "^4.7.0",
+        "luxon": "^3.7.2",
+      },
       "devDependencies": {
         "@biomejs/biome": "1.9.4",
         "@types/bun": "^1.3.13",
+        "@types/luxon": "^3.7.1",
         "typescript": "^5.8.3",
       },
     },
@@ -150,6 +155,8 @@
 
     "@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
 
+    "@types/luxon": ["@types/luxon@3.7.1", "", {}, "sha512-H3iskjFIAn5SlJU7OuxUmTEpebK6TKB8rxZShDslBMZJ5u9S//KM1sbdAisiSrqwLQncVjnpi2OK2J51h+4lsg=="],
+
     "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
 
     "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
@@ -166,6 +173,10 @@
 
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
+    "fast-check": ["fast-check@4.7.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-NsZRtqvSSoCP0HbNjUD+r1JH8zqZalyp6gLY9e7OYs7NK9b6AHOs2baBFeBG7bVNsuoukh89x2Yg3rPsul8ziQ=="],
+
+    "luxon": ["luxon@3.7.2", "", {}, "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew=="],
+
     "nanoid": ["nanoid@3.3.12", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ=="],
 
     "next": ["next@15.5.15", "", { "dependencies": { "@next/env": "15.5.15", "@swc/helpers": "0.5.15", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "15.5.15", "@next/swc-darwin-x64": "15.5.15", "@next/swc-linux-arm64-gnu": "15.5.15", "@next/swc-linux-arm64-musl": "15.5.15", "@next/swc-linux-x64-gnu": "15.5.15", "@next/swc-linux-x64-musl": "15.5.15", "@next/swc-win32-arm64-msvc": "15.5.15", "@next/swc-win32-x64-msvc": "15.5.15", "sharp": "^0.34.3" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-VSqCrJwtLVGwAVE0Sb/yikrQfkwkZW9p+lL/J4+xe+G3ZA+QnWPqgcfH1tDUEuk9y+pthzzVFp4L/U8JerMfMQ=="],
@@ -173,6 +184,8 @@
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
+
+    "pure-rand": ["pure-rand@8.4.0", "", {}, "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A=="],
 
     "react": ["react@19.2.5", "", {}, "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA=="],
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,11 @@
   "devDependencies": {
     "@biomejs/biome": "1.9.4",
     "@types/bun": "^1.3.13",
+    "@types/luxon": "^3.7.1",
     "typescript": "^5.8.3"
+  },
+  "dependencies": {
+    "fast-check": "^4.7.0",
+    "luxon": "^3.7.2"
   }
 }

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -1,4 +1,4 @@
 // @calendry/core — slot generation, booking state machine, ICS generation, time math
-// Implementations land in Sprint 1+ (see SPEC.md §Implementation Plan)
 
-export {};
+export type { AvailabilityRule, BusyBlock, Slot } from "./src/slot-gen";
+export { generateSlots } from "./src/slot-gen";

--- a/packages/core/src/slot-gen.ts
+++ b/packages/core/src/slot-gen.ts
@@ -208,11 +208,17 @@ function buildLocalDateTime(
 
 /**
  * Validate that no two rules overlap on the same weekday.
- * Two rules overlap if their time ranges intersect (touching is allowed).
+ * Two rules overlap if their time ranges intersect (touching is allowed)
+ * AND their valid_from/valid_to date ranges intersect.
  *
  * why: SPEC §Availability rule semantics — overlapping windows for the same
  * weekday are rejected to avoid silent ambiguity. Adjacent rules (touching)
- * are permitted.
+ * are permitted. Rules whose date ranges are disjoint can share a weekday
+ * with overlapping time windows (e.g. "normal Tuesdays 10–4 except July
+ * when 12–4" uses valid_to=Jun 30 + valid_from=Jul 1).
+ *
+ * Null/undefined valid_from is treated as -infinity; null/undefined valid_to
+ * as +infinity. A rule without both bounds is effective for all dates.
  */
 function validateRules(rules: AvailabilityRule[]): void {
   for (let i = 0; i < rules.length; i++) {
@@ -221,6 +227,21 @@ function validateRules(rules: AvailabilityRule[]): void {
       const b = rules[j];
       if (a.weekday !== b.weekday) continue;
 
+      // Short-circuit: if the date ranges do not intersect, these two rules
+      // can never be active on the same calendar day — no conflict possible.
+      // Date range overlap: a.valid_from <= b.valid_to AND b.valid_from <= a.valid_to
+      // Null valid_from = -infinity; null valid_to = +infinity.
+      const aFrom = a.valid_from ?? null;
+      const aTo = a.valid_to ?? null;
+      const bFrom = b.valid_from ?? null;
+      const bTo = b.valid_to ?? null;
+
+      // a's range ends before b's range starts → disjoint
+      if (aTo !== null && bFrom !== null && aTo < bFrom) continue;
+      // b's range ends before a's range starts → disjoint
+      if (bTo !== null && aFrom !== null && bTo < aFrom) continue;
+
+      // Date ranges intersect — now check time overlap.
       // Overlap iff a.start_local < b.end_local AND b.start_local < a.end_local
       // (strict inequalities — touching endpoints are allowed)
       if (a.start_local < b.end_local && b.start_local < a.end_local) {

--- a/packages/core/src/slot-gen.ts
+++ b/packages/core/src/slot-gen.ts
@@ -1,0 +1,251 @@
+/**
+ * slot-gen.ts — pure slot-generation function for Calendry.
+ *
+ * Generates bookable time slots from availability rules, minus busy blocks,
+ * within a UTC window. Uses Luxon for all timezone math.
+ *
+ * NO I/O. NO Date.now(). Pure function.
+ *
+ * @module slot-gen
+ */
+
+import { DateTime } from "luxon";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface AvailabilityRule {
+  /** ISO weekday 1=Monday … 7=Sunday */
+  weekday: 1 | 2 | 3 | 4 | 5 | 6 | 7;
+  /** Minutes from midnight (local) when availability starts, e.g. 600 = 10am */
+  start_local: number;
+  /** Minutes from midnight (local) when availability ends, e.g. 960 = 4pm */
+  end_local: number;
+  /** Session length in minutes */
+  slot_minutes: number;
+  /**
+   * Buffer applied AFTER session only.
+   * why: v0.1 decision — pre-buffer rejected for rule-model simplicity;
+   * grid = slot_minutes + buffer_minutes. Revisit in v0.2 if requested.
+   */
+  buffer_minutes: number;
+  /** IANA timezone for this rule (provider's home zone). */
+  zone: string;
+  /** Optional date bounds (inclusive) in the provider's zone. */
+  valid_from: DateTime | null;
+  valid_to: DateTime | null;
+}
+
+export interface BusyBlock {
+  startUtc: DateTime;
+  endUtc: DateTime;
+}
+
+export interface Slot {
+  startUtc: DateTime;
+  durationMinutes: number;
+  /** Provider's IANA zone — stored for email rendering; never affects UTC. */
+  providerZone: string;
+}
+
+// ---------------------------------------------------------------------------
+// generateSlots
+// ---------------------------------------------------------------------------
+
+/**
+ * Generate available time slots.
+ *
+ * @param args.rules     Availability rules. Two rules that overlap on the same
+ *                       weekday cause a throw (no silent merge — per SPEC
+ *                       §Availability rule semantics).
+ * @param args.busy      Busy blocks to exclude from output.
+ * @param args.window    UTC window to constrain output.
+ * @param args.providerZone  IANA zone used to expand recurrence rules.
+ * @param args.renderZone    Cosmetic only — ignored in UTC math.
+ */
+export function generateSlots(args: {
+  rules: AvailabilityRule[];
+  busy: BusyBlock[];
+  window: { startUtc: DateTime; endUtc: DateTime };
+  providerZone: string;
+  renderZone: string; // why: cosmetic only — caller may render in any zone
+}): Slot[] {
+  const { rules, busy, window: win, providerZone } = args;
+
+  // --- 1. Reject overlapping rules on the same weekday ----------------------
+  validateRules(rules);
+
+  // --- 2. Walk each calendar day in the window (in the provider's zone) -----
+  const slots: Slot[] = [];
+
+  // Iterate day by day from the start of the window to the end.
+  // We advance by calendar date in the providerZone to correctly handle DST.
+  let dayStart = win.startUtc.setZone(providerZone).startOf("day");
+  const windowEnd = win.endUtc;
+
+  while (dayStart.toUTC() < windowEnd) {
+    const dayWeekday = dayStart.weekday as 1 | 2 | 3 | 4 | 5 | 6 | 7;
+
+    for (const rule of rules) {
+      if (rule.weekday !== dayWeekday) continue;
+
+      // Check valid_from / valid_to date bounds
+      if (rule.valid_from !== null && dayStart < rule.valid_from.startOf("day")) continue;
+      if (rule.valid_to !== null && dayStart > rule.valid_to.endOf("day")) continue;
+
+      const gridMinutes = rule.slot_minutes + rule.buffer_minutes;
+      const slotsForDay = expandRuleOnDay(rule, dayStart, gridMinutes, win, providerZone);
+      slots.push(...slotsForDay);
+    }
+
+    dayStart = dayStart.plus({ days: 1 });
+  }
+
+  // --- 3. Filter out busy-colliding slots ------------------------------------
+  return slots.filter((slot) => !collidesWithBusy(slot, busy));
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Expand a single availability rule on a single calendar day in the provider
+ * zone. Returns candidate slots that:
+ *   - start within [window.startUtc, window.endUtc)
+ *   - are not in a DST gap
+ *   - are deduplicated across a fall-back fold (emit UTC-earliest occurrence)
+ */
+function expandRuleOnDay(
+  rule: AvailabilityRule,
+  dayInZone: DateTime, // start-of-day in providerZone
+  gridMinutes: number,
+  win: { startUtc: DateTime; endUtc: DateTime },
+  providerZone: string,
+): Slot[] {
+  const slots: Slot[] = [];
+
+  // Seen UTC millis — guards against emitting a fold instant twice.
+  // why: during a fall-back fold a wall-clock time maps to two UTC instants.
+  // We emit the FIRST UTC instant (pre-fold, the "earlier" one).
+  // Luxon's DateTime.fromObject in an ambiguous fold zone returns the
+  // pre-fold instant by default (keepLocalTime behaviour).
+  const seenUtcMillis = new Set<number>();
+
+  let offsetMinutes = rule.start_local;
+  while (offsetMinutes + rule.slot_minutes <= rule.end_local) {
+    const candidateLocal = buildLocalDateTime(dayInZone, offsetMinutes, providerZone);
+
+    if (candidateLocal !== null) {
+      const candidateUtc = candidateLocal.toUTC();
+      const slotEndUtc = candidateUtc.plus({ minutes: rule.slot_minutes });
+
+      // Must be fully inside the window
+      if (
+        candidateUtc >= win.startUtc &&
+        slotEndUtc <= win.endUtc &&
+        !seenUtcMillis.has(candidateUtc.toMillis())
+      ) {
+        seenUtcMillis.add(candidateUtc.toMillis());
+        slots.push({
+          startUtc: candidateUtc,
+          durationMinutes: rule.slot_minutes,
+          providerZone,
+        });
+      }
+    }
+
+    offsetMinutes += gridMinutes;
+  }
+
+  return slots;
+}
+
+/**
+ * Build a DateTime in the provider zone for a given day + minutes-from-midnight.
+ * Returns null if the resulting local time falls in a DST gap (invalid time).
+ *
+ * DST gap detection: construct via fromObject, then verify the UTC round-trip
+ * matches. If Luxon shifted the time (gap), the UTC round-trip will differ.
+ *
+ * why: Luxon's DateTime.fromObject in a gap zone does not return isValid=false;
+ * instead it advances the clock past the gap. We detect this by comparing the
+ * re-converted local time to the original requested local time.
+ */
+function buildLocalDateTime(
+  dayStart: DateTime,
+  minutesFromMidnight: number,
+  zone: string,
+): DateTime | null {
+  const hour = Math.floor(minutesFromMidnight / 60);
+  const minute = minutesFromMidnight % 60;
+
+  const candidate = DateTime.fromObject(
+    {
+      year: dayStart.year,
+      month: dayStart.month,
+      day: dayStart.day,
+      hour,
+      minute,
+      second: 0,
+      millisecond: 0,
+    },
+    { zone },
+  );
+
+  if (!candidate.isValid) return null;
+
+  // DST gap check: if Luxon shifted the time forward out of the gap,
+  // the local hour/minute will differ from what we requested.
+  if (candidate.hour !== hour || candidate.minute !== minute) {
+    // Time was in a DST gap — Luxon advanced it; we omit this slot.
+    return null;
+  }
+
+  return candidate;
+}
+
+/**
+ * Validate that no two rules overlap on the same weekday.
+ * Two rules overlap if their time ranges intersect (touching is allowed).
+ *
+ * why: SPEC §Availability rule semantics — overlapping windows for the same
+ * weekday are rejected to avoid silent ambiguity. Adjacent rules (touching)
+ * are permitted.
+ */
+function validateRules(rules: AvailabilityRule[]): void {
+  for (let i = 0; i < rules.length; i++) {
+    for (let j = i + 1; j < rules.length; j++) {
+      const a = rules[i];
+      const b = rules[j];
+      if (a.weekday !== b.weekday) continue;
+
+      // Overlap iff a.start_local < b.end_local AND b.start_local < a.end_local
+      // (strict inequalities — touching endpoints are allowed)
+      if (a.start_local < b.end_local && b.start_local < a.end_local) {
+        throw new Error(
+          `Overlapping availability rules for weekday ${a.weekday}: ` +
+            `rule A [${a.start_local}–${a.end_local}] overlaps ` +
+            `rule B [${b.start_local}–${b.end_local}]`,
+        );
+      }
+    }
+  }
+}
+
+/**
+ * Returns true if the slot overlaps (not merely touches) any busy block.
+ *
+ * Overlap condition: slot.start < busy.end AND slot.end > busy.start
+ * Touching (slot.end == busy.start, or slot.start == busy.end) is NOT overlap.
+ */
+function collidesWithBusy(slot: Slot, busy: BusyBlock[]): boolean {
+  const slotEnd = slot.startUtc.plus({ minutes: slot.durationMinutes });
+  for (const b of busy) {
+    if (slot.startUtc < b.endUtc && slotEnd > b.startUtc) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/tests/unit/slot-gen.test.ts
+++ b/tests/unit/slot-gen.test.ts
@@ -76,7 +76,36 @@ const IANA_ZONES = [
 const ianaZoneArb = fc.constantFrom(...IANA_ZONES);
 
 /** Arbitrary slot_minutes in [15, 120] step 5 */
-const slotMinutesArb = fc.integer({ min: 1, max: 24 }).map((n) => n * 5 as 5 | 10 | 15 | 20 | 25 | 30 | 35 | 40 | 45 | 50 | 55 | 60 | 65 | 70 | 75 | 80 | 85 | 90 | 95 | 100 | 105 | 110 | 115 | 120);
+const slotMinutesArb = fc
+  .integer({ min: 1, max: 24 })
+  .map(
+    (n) =>
+      (n * 5) as
+        | 5
+        | 10
+        | 15
+        | 20
+        | 25
+        | 30
+        | 35
+        | 40
+        | 45
+        | 50
+        | 55
+        | 60
+        | 65
+        | 70
+        | 75
+        | 80
+        | 85
+        | 90
+        | 95
+        | 100
+        | 105
+        | 110
+        | 115
+        | 120,
+  );
 
 /** Arbitrary buffer_minutes in [0, 60] step 5 */
 const bufferMinutesArb = fc.integer({ min: 0, max: 12 }).map((n) => n * 5);
@@ -92,36 +121,32 @@ const availabilityRuleArb: fc.Arbitrary<AvailabilityRule> = fc
   .chain(([weekday, slotMinutes, bufferMinutes, zone]) => {
     const gridMinutes = slotMinutes + bufferMinutes;
     // startHour 8..15, endHour must allow at least one slot
-    return fc
-      .integer({ min: 8, max: 15 })
-      .chain((startHour) => {
-        const minEndMinutes = startHour * 60 + gridMinutes;
-        const maxEndMinutes = 22 * 60;
-        if (minEndMinutes >= maxEndMinutes) return fc.constant(null);
-        return fc.integer({ min: minEndMinutes, max: maxEndMinutes }).map((endMinutes) => ({
-          weekday,
-          start_local: startHour * 60,
-          end_local: endMinutes,
-          slot_minutes: slotMinutes,
-          buffer_minutes: bufferMinutes,
-          zone,
-          valid_from: null,
-          valid_to: null,
-        }));
-      });
+    return fc.integer({ min: 8, max: 15 }).chain((startHour) => {
+      const minEndMinutes = startHour * 60 + gridMinutes;
+      const maxEndMinutes = 22 * 60;
+      if (minEndMinutes >= maxEndMinutes) return fc.constant(null);
+      return fc.integer({ min: minEndMinutes, max: maxEndMinutes }).map((endMinutes) => ({
+        weekday,
+        start_local: startHour * 60,
+        end_local: endMinutes,
+        slot_minutes: slotMinutes,
+        buffer_minutes: bufferMinutes,
+        zone,
+        valid_from: null,
+        valid_to: null,
+      }));
+    });
   })
   .filter((r): r is AvailabilityRule => r !== null);
 
 /** Arbitrary UTC window of 1..14 days starting somewhere in 2025. */
-const windowArb = fc
-  .integer({ min: 0, max: 364 })
-  .chain((dayOffset) => {
-    const base = DateTime.fromISO("2025-01-01T00:00:00Z");
-    const startUtc = base.plus({ days: dayOffset });
-    return fc
-      .integer({ min: 1, max: 14 })
-      .map((len) => ({ startUtc, endUtc: startUtc.plus({ days: len }) }));
-  });
+const windowArb = fc.integer({ min: 0, max: 364 }).chain((dayOffset) => {
+  const base = DateTime.fromISO("2025-01-01T00:00:00Z");
+  const startUtc = base.plus({ days: dayOffset });
+  return fc
+    .integer({ min: 1, max: 14 })
+    .map((len) => ({ startUtc, endUtc: startUtc.plus({ days: len }) }));
+});
 
 /** Arbitrary array of busy blocks within a window (0..4 blocks). */
 function busyBlocksArb(win: {
@@ -129,20 +154,23 @@ function busyBlocksArb(win: {
   endUtc: DateTime;
 }): fc.Arbitrary<BusyBlock[]> {
   const windowMs = win.endUtc.toMillis() - win.startUtc.toMillis();
-  return fc
-    .array(
-      fc.tuple(fc.float({ min: 0, max: 0.9 }), fc.float({ min: 0.01, max: 0.2 })).map(
-        ([startFrac, lenFrac]) => {
-          const startMs = win.startUtc.toMillis() + Math.floor(startFrac * windowMs);
-          const endMs = startMs + Math.floor(Math.min(lenFrac, 0.1) * windowMs) + 60_000;
-          return busy(
-            DateTime.fromMillis(startMs, { zone: "UTC" }),
-            DateTime.fromMillis(endMs, { zone: "UTC" }),
-          );
-        },
-      ),
-      { minLength: 0, maxLength: 4 },
-    );
+  // Use integers (percentages 0..99) instead of floats to avoid 32-bit float constraints
+  return fc.array(
+    fc
+      .tuple(
+        fc.integer({ min: 0, max: 89 }), // start pct 0..89%
+        fc.integer({ min: 1, max: 10 }), // length pct 1..10%
+      )
+      .map(([startPct, lenPct]) => {
+        const startMs = win.startUtc.toMillis() + Math.floor((startPct / 100) * windowMs);
+        const endMs = startMs + Math.floor((lenPct / 100) * windowMs) + 60_000;
+        return busy(
+          DateTime.fromMillis(startMs, { zone: "UTC" }),
+          DateTime.fromMillis(endMs, { zone: "UTC" }),
+        );
+      }),
+    { minLength: 0, maxLength: 4 },
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -181,9 +209,7 @@ describe("Property 2: every slot is disjoint from busy blocks (touching allowed)
     fc.assert(
       fc.property(
         availabilityRuleArb,
-        windowArb.chain((win) =>
-          busyBlocksArb(win).map((blocks) => ({ win, blocks })),
-        ),
+        windowArb.chain((win) => busyBlocksArb(win).map((blocks) => ({ win, blocks }))),
         ianaZoneArb,
         (r, { win, blocks }, renderZone) => {
           const slots = generateSlots({
@@ -197,8 +223,7 @@ describe("Property 2: every slot is disjoint from busy blocks (touching allowed)
             const slotEnd = s.startUtc.plus({ minutes: s.durationMinutes });
             for (const b of blocks) {
               // overlap iff startUtc < b.endUtc && slotEnd > b.startUtc
-              const overlaps =
-                s.startUtc < b.endUtc && slotEnd > b.startUtc;
+              const overlaps = s.startUtc < b.endUtc && slotEnd > b.startUtc;
               if (overlaps) return false;
             }
           }
@@ -250,40 +275,35 @@ describe("Property 3: slot starts align to (slot+buffer) grid relative to start_
 describe("Property 4: slot count is non-increasing as busy grows", () => {
   it("holds for ≥200 cases", () => {
     fc.assert(
-      fc.property(
-        availabilityRuleArb,
-        windowArb,
-        ianaZoneArb,
-        (r, win, renderZone) => {
-          // Generate slots with no busy
-          const allSlots = generateSlots({
-            rules: [r],
-            busy: [],
-            window: win,
-            providerZone: r.zone,
-            renderZone,
-          });
+      fc.property(availabilityRuleArb, windowArb, ianaZoneArb, (r, win, renderZone) => {
+        // Generate slots with no busy
+        const allSlots = generateSlots({
+          rules: [r],
+          busy: [],
+          window: win,
+          providerZone: r.zone,
+          renderZone,
+        });
 
-          if (allSlots.length === 0) return true; // nothing to test
+        if (allSlots.length === 0) return true; // nothing to test
 
-          // Pick first slot as a busy block, count must drop or stay same
-          const firstSlot = allSlots[0];
-          const blocker = busy(
-            firstSlot.startUtc,
-            firstSlot.startUtc.plus({ minutes: firstSlot.durationMinutes }),
-          );
+        // Pick first slot as a busy block, count must drop or stay same
+        const firstSlot = allSlots[0];
+        const blocker = busy(
+          firstSlot.startUtc,
+          firstSlot.startUtc.plus({ minutes: firstSlot.durationMinutes }),
+        );
 
-          const fewerSlots = generateSlots({
-            rules: [r],
-            busy: [blocker],
-            window: win,
-            providerZone: r.zone,
-            renderZone,
-          });
+        const fewerSlots = generateSlots({
+          rules: [r],
+          busy: [blocker],
+          window: win,
+          providerZone: r.zone,
+          renderZone,
+        });
 
-          return fewerSlots.length <= allSlots.length;
-        },
-      ),
+        return fewerSlots.length <= allSlots.length;
+      }),
       { numRuns: 200 },
     );
   });
@@ -367,7 +387,11 @@ describe("Property 6: no slot starts inside a DST gap", () => {
     fc.assert(
       fc.property(
         fc.tuple(availabilityRuleArb, gapZoneArb, springWindowArb).map(([r, zone, win]) => ({
-          r: { ...r, zone, weekday: win.startUtc.setZone(zone).weekday as 1|2|3|4|5|6|7 },
+          r: {
+            ...r,
+            zone,
+            weekday: win.startUtc.setZone(zone).weekday as 1 | 2 | 3 | 4 | 5 | 6 | 7,
+          },
           zone,
           win,
         })),
@@ -384,7 +408,13 @@ describe("Property 6: no slot starts inside a DST gap", () => {
             const local = s.startUtc.setZone(zone);
             // A time in a gap is invalid in Luxon when constructed via fromObject
             const reconstructed = DateTime.fromObject(
-              { year: local.year, month: local.month, day: local.day, hour: local.hour, minute: local.minute },
+              {
+                year: local.year,
+                month: local.month,
+                day: local.day,
+                hour: local.hour,
+                minute: local.minute,
+              },
               { zone },
             );
             // If the reconstructed time is invalid or has been shifted (gap),
@@ -448,9 +478,15 @@ describe("Property 7: fall-back fold hour yields exactly one slot per UTC instan
         (zone) => {
           // Fall-back windows for each zone
           const fallbacks: Record<string, { startUtc: string; endUtc: string }> = {
-            "America/New_York": { startUtc: "2025-11-02T04:00:00Z", endUtc: "2025-11-02T10:00:00Z" },
+            "America/New_York": {
+              startUtc: "2025-11-02T04:00:00Z",
+              endUtc: "2025-11-02T10:00:00Z",
+            },
             "America/Chicago": { startUtc: "2025-11-02T05:00:00Z", endUtc: "2025-11-02T10:00:00Z" },
-            "America/Los_Angeles": { startUtc: "2025-11-02T07:00:00Z", endUtc: "2025-11-02T12:00:00Z" },
+            "America/Los_Angeles": {
+              startUtc: "2025-11-02T07:00:00Z",
+              endUtc: "2025-11-02T12:00:00Z",
+            },
           };
           const fb = fallbacks[zone];
           const foldWin = {
@@ -489,70 +525,67 @@ describe("Property 7: fall-back fold hour yields exactly one slot per UTC instan
 
 describe("Property 8: overlapping rules with same weekday throw", () => {
   it("throws when two rules for the same weekday have overlapping time ranges", () => {
+    // Build a pair of genuinely-overlapping rules: both same weekday,
+    // r2.start_local is strictly inside r1's range.
     fc.assert(
-      fc.property(
-        availabilityRuleArb,
-        ianaZoneArb,
-        (r, renderZone) => {
-          // Create a second rule that overlaps: same weekday, same zone, start_local shifted by 30 min
-          const r2: AvailabilityRule = {
-            ...r,
-            start_local: r.start_local + 30,
-            end_local: r.end_local + 30,
-          };
-          const win = {
-            startUtc: DateTime.fromISO("2025-01-01T00:00:00Z"),
-            endUtc: DateTime.fromISO("2025-01-15T00:00:00Z"),
-          };
-          let threw = false;
-          try {
-            generateSlots({
-              rules: [r, r2],
-              busy: [],
-              window: win,
-              providerZone: r.zone,
-              renderZone,
-            });
-          } catch {
-            threw = true;
-          }
-          return threw;
-        },
-      ),
+      fc.property(availabilityRuleArb, ianaZoneArb, (r, renderZone) => {
+        const rangeMinutes = r.end_local - r.start_local;
+        if (rangeMinutes < 2) return true; // skip degenerate rules
+        // r2 starts in the middle of r1 and ends after r1 — guaranteed overlap
+        const overlapStart = r.start_local + Math.floor(rangeMinutes / 2);
+        const r2: AvailabilityRule = {
+          ...r,
+          start_local: overlapStart,
+          end_local: r.end_local + r.slot_minutes + r.buffer_minutes,
+        };
+        const win = {
+          startUtc: DateTime.fromISO("2025-01-01T00:00:00Z"),
+          endUtc: DateTime.fromISO("2025-01-15T00:00:00Z"),
+        };
+        let threw = false;
+        try {
+          generateSlots({
+            rules: [r, r2],
+            busy: [],
+            window: win,
+            providerZone: r.zone,
+            renderZone,
+          });
+        } catch {
+          threw = true;
+        }
+        return threw;
+      }),
       { numRuns: 200 },
     );
   });
 
   it("does NOT throw when rules have different weekdays", () => {
     fc.assert(
-      fc.property(
-        availabilityRuleArb,
-        ianaZoneArb,
-        (r, renderZone) => {
-          const otherWeekday = ((r.weekday % 7) + 1) as 1 | 2 | 3 | 4 | 5 | 6 | 7;
-          const r2: AvailabilityRule = {
-            ...r,
-            weekday: otherWeekday,
-          };
-          const win = {
-            startUtc: DateTime.fromISO("2025-01-01T00:00:00Z"),
-            endUtc: DateTime.fromISO("2025-01-15T00:00:00Z"),
-          };
-          let threw = false;
-          try {
-            generateSlots({
-              rules: [r, r2],
-              busy: [],
-              window: win,
-              providerZone: r.zone,
-              renderZone,
-            });
-          } catch {
-            threw = true;
-          }
-          return !threw;
-        },
-      ),
+      fc.property(availabilityRuleArb, ianaZoneArb, (r, renderZone) => {
+        const otherWeekday = ((r.weekday % 7) + 1) as 1 | 2 | 3 | 4 | 5 | 6 | 7;
+        const r2: AvailabilityRule = {
+          ...r,
+          weekday: otherWeekday,
+        };
+        const win = {
+          startUtc: DateTime.fromISO("2025-01-01T00:00:00Z"),
+          endUtc: DateTime.fromISO("2025-01-15T00:00:00Z"),
+        };
+        let threw = false;
+        try {
+          generateSlots({
+            rules: [r, r2],
+            busy: [],
+            window: win,
+            providerZone: r.zone,
+            renderZone,
+          });
+        } catch {
+          threw = true;
+        }
+        return !threw;
+      }),
       { numRuns: 200 },
     );
   });
@@ -593,15 +626,21 @@ describe("Fixture: US DST spring-forward gap slot omitted", () => {
       renderZone: "America/New_York",
     });
 
-    // No slot should start at a UTC time that falls in the gap.
-    // Gap in UTC: 07:00Z to 07:59Z (2am–2:59am ET, which don't exist)
+    // No slot should have a local time in the DST gap.
+    // Gap: 2:00am–2:59am America/New_York on Mar 9 2025 do not exist.
+    // Luxon shifts fromObject calls in that range forward to 3am, so our
+    // implementation skips them. Verify no emitted slot has local hour=2.
     for (const s of slots) {
-      const utcHour = s.startUtc.toUTC().hour;
-      const utcMin = s.startUtc.toUTC().minute;
-      const utcMinutes = utcHour * 60 + utcMin;
-      // 07:00Z–07:59Z is the gap
-      expect(utcMinutes >= 7 * 60 && utcMinutes < 8 * 60).toBe(false);
+      const local = s.startUtc.setZone("America/New_York");
+      // Local 2:x am does not exist on this date (DST gap)
+      expect(local.hour).not.toBe(2);
     }
+    // The gap slots are omitted, so we should have 23 half-hour slots
+    // (24*2=48 minus the 2 gap slots for 2:00am and 2:30am = 46), but the
+    // window is only 12 UTC hours (0Z–12Z), so let's just check count:
+    // 0Z = midnight ET, 12Z = 8am EDT. That spans midnight to 8am local.
+    // With 30-min grid: 0:00,0:30,1:00,1:30,[2:00-skip],[2:30-skip],3:00,3:30,4:00,4:30,5:00,5:30,6:00,6:30,7:00,7:30 = 14 slots
+    expect(slots.length).toBe(14);
   });
 
   it("omits slots in the 2am gap on Mar 8 2026 (NY spring forward)", () => {
@@ -627,12 +666,13 @@ describe("Fixture: US DST spring-forward gap slot omitted", () => {
       renderZone: "America/New_York",
     });
 
+    // Same as above: no slot with local hour=2 on spring-forward day
     for (const s of slots) {
-      const utcHour = s.startUtc.toUTC().hour;
-      const utcMin = s.startUtc.toUTC().minute;
-      const utcMinutes = utcHour * 60 + utcMin;
-      expect(utcMinutes >= 7 * 60 && utcMinutes < 8 * 60).toBe(false);
+      const local = s.startUtc.setZone("America/New_York");
+      expect(local.hour).not.toBe(2);
     }
+    // Same 14 slots: midnight to 8am local, 2 gap slots omitted
+    expect(slots.length).toBe(14);
   });
 });
 
@@ -660,7 +700,7 @@ describe("Fixture: US DST fall-back fold hour offered exactly once", () => {
     };
     const win = {
       startUtc: DateTime.fromISO("2025-11-02T04:00:00Z"), // midnight ET
-      endUtc: DateTime.fromISO("2025-11-02T10:00:00Z"),   // 5am ET (post-fold)
+      endUtc: DateTime.fromISO("2025-11-02T10:00:00Z"), // 5am ET (post-fold)
     };
     const slots = generateSlots({
       rules: [r],
@@ -753,7 +793,7 @@ describe("Fixture: Madrid provider + NYC booker, US/EU DST divergence window", (
     const r: AvailabilityRule = {
       weekday: 7, // Sunday Mar 29 2026
       start_local: 1 * 60, // 1am
-      end_local: 4 * 60,   // 4am
+      end_local: 4 * 60, // 4am
       slot_minutes: 30,
       buffer_minutes: 0,
       zone: "Europe/Madrid",
@@ -776,7 +816,10 @@ describe("Fixture: Madrid provider + NYC booker, US/EU DST divergence window", (
     for (const s of slots) {
       const local = s.startUtc.setZone("Europe/Madrid");
       // 2:00–2:59am CET does not exist on Mar 29
-      const gapStart = DateTime.fromObject({ year: 2026, month: 3, day: 29, hour: 2, minute: 0 }, { zone: "Europe/Madrid" });
+      const gapStart = DateTime.fromObject(
+        { year: 2026, month: 3, day: 29, hour: 2, minute: 0 },
+        { zone: "Europe/Madrid" },
+      );
       // If in gap, Luxon will return invalid or shift to 3am. Verify no slot
       // has a local time in that gap range.
       if (local.hour === 2) {
@@ -1033,7 +1076,7 @@ describe("Fixture: buffer applied AFTER session (Maya 50/10 → 60-min grid, 6 s
     // Verify grid alignment: each slot starts on a 60-min boundary from 10am
     for (const s of tuesdaySlots) {
       const local = s.startUtc.setZone("America/Los_Angeles");
-      const minutesFrom10am = (local.hour * 60 + local.minute) - 10 * 60;
+      const minutesFrom10am = local.hour * 60 + local.minute - 10 * 60;
       expect(minutesFrom10am >= 0).toBe(true);
       expect(minutesFrom10am % 60).toBe(0);
     }

--- a/tests/unit/slot-gen.test.ts
+++ b/tests/unit/slot-gen.test.ts
@@ -1,0 +1,1126 @@
+/**
+ * slot-gen.test.ts
+ *
+ * 8 property-based invariants (≥200 cases each via fast-check) +
+ * required fixed-case DST and scheduling fixtures.
+ *
+ * TDD commit: this file is written BEFORE slot-gen.ts exists.
+ * Run: bun test tests/unit/slot-gen.test.ts
+ */
+
+import { describe, expect, it } from "bun:test";
+import * as fc from "fast-check";
+import { DateTime } from "luxon";
+import { generateSlots } from "../../packages/core/src/slot-gen";
+import type { AvailabilityRule, BusyBlock, Slot } from "../../packages/core/src/slot-gen";
+
+// ---------------------------------------------------------------------------
+// Helpers shared across tests
+// ---------------------------------------------------------------------------
+
+/** Build a DateTime in the given IANA zone at a specific date+time. */
+function dt(
+  zone: string,
+  year: number,
+  month: number,
+  day: number,
+  hour: number,
+  minute = 0,
+): DateTime {
+  return DateTime.fromObject({ year, month, day, hour, minute }, { zone });
+}
+
+/** Build a simple rule for a given weekday (1=Mon…7=Sun in Luxon ISO) */
+function rule(
+  weekday: 1 | 2 | 3 | 4 | 5 | 6 | 7,
+  startHour: number,
+  endHour: number,
+  slotMinutes: number,
+  bufferMinutes: number,
+  zone: string,
+  validFrom?: DateTime,
+  validTo?: DateTime,
+): AvailabilityRule {
+  return {
+    weekday,
+    start_local: startHour * 60, // minutes from midnight
+    end_local: endHour * 60,
+    slot_minutes: slotMinutes,
+    buffer_minutes: bufferMinutes,
+    zone,
+    valid_from: validFrom ?? null,
+    valid_to: validTo ?? null,
+  };
+}
+
+/** Build a busy block from two UTC DateTimes. */
+function busy(startUtc: DateTime, endUtc: DateTime): BusyBlock {
+  return { startUtc, endUtc };
+}
+
+// ---------------------------------------------------------------------------
+// fast-check arbitraries
+// ---------------------------------------------------------------------------
+
+const IANA_ZONES = [
+  "America/New_York",
+  "America/Los_Angeles",
+  "America/Chicago",
+  "Europe/Madrid",
+  "Europe/London",
+  "Asia/Tokyo",
+  "Australia/Sydney",
+  "UTC",
+];
+
+const ianaZoneArb = fc.constantFrom(...IANA_ZONES);
+
+/** Arbitrary slot_minutes in [15, 120] step 5 */
+const slotMinutesArb = fc.integer({ min: 1, max: 24 }).map((n) => n * 5 as 5 | 10 | 15 | 20 | 25 | 30 | 35 | 40 | 45 | 50 | 55 | 60 | 65 | 70 | 75 | 80 | 85 | 90 | 95 | 100 | 105 | 110 | 115 | 120);
+
+/** Arbitrary buffer_minutes in [0, 60] step 5 */
+const bufferMinutesArb = fc.integer({ min: 0, max: 12 }).map((n) => n * 5);
+
+/** Weekday 1..7 */
+const weekdayArb = fc.integer({ min: 1, max: 7 }) as fc.Arbitrary<1 | 2 | 3 | 4 | 5 | 6 | 7>;
+
+/**
+ * Arbitrary AvailabilityRule with valid slot grid (end - start >= slot + buffer).
+ */
+const availabilityRuleArb: fc.Arbitrary<AvailabilityRule> = fc
+  .tuple(weekdayArb, slotMinutesArb, bufferMinutesArb, ianaZoneArb)
+  .chain(([weekday, slotMinutes, bufferMinutes, zone]) => {
+    const gridMinutes = slotMinutes + bufferMinutes;
+    // startHour 8..15, endHour must allow at least one slot
+    return fc
+      .integer({ min: 8, max: 15 })
+      .chain((startHour) => {
+        const minEndMinutes = startHour * 60 + gridMinutes;
+        const maxEndMinutes = 22 * 60;
+        if (minEndMinutes >= maxEndMinutes) return fc.constant(null);
+        return fc.integer({ min: minEndMinutes, max: maxEndMinutes }).map((endMinutes) => ({
+          weekday,
+          start_local: startHour * 60,
+          end_local: endMinutes,
+          slot_minutes: slotMinutes,
+          buffer_minutes: bufferMinutes,
+          zone,
+          valid_from: null,
+          valid_to: null,
+        }));
+      });
+  })
+  .filter((r): r is AvailabilityRule => r !== null);
+
+/** Arbitrary UTC window of 1..14 days starting somewhere in 2025. */
+const windowArb = fc
+  .integer({ min: 0, max: 364 })
+  .chain((dayOffset) => {
+    const base = DateTime.fromISO("2025-01-01T00:00:00Z");
+    const startUtc = base.plus({ days: dayOffset });
+    return fc
+      .integer({ min: 1, max: 14 })
+      .map((len) => ({ startUtc, endUtc: startUtc.plus({ days: len }) }));
+  });
+
+/** Arbitrary array of busy blocks within a window (0..4 blocks). */
+function busyBlocksArb(win: {
+  startUtc: DateTime;
+  endUtc: DateTime;
+}): fc.Arbitrary<BusyBlock[]> {
+  const windowMs = win.endUtc.toMillis() - win.startUtc.toMillis();
+  return fc
+    .array(
+      fc.tuple(fc.float({ min: 0, max: 0.9 }), fc.float({ min: 0.01, max: 0.2 })).map(
+        ([startFrac, lenFrac]) => {
+          const startMs = win.startUtc.toMillis() + Math.floor(startFrac * windowMs);
+          const endMs = startMs + Math.floor(Math.min(lenFrac, 0.1) * windowMs) + 60_000;
+          return busy(
+            DateTime.fromMillis(startMs, { zone: "UTC" }),
+            DateTime.fromMillis(endMs, { zone: "UTC" }),
+          );
+        },
+      ),
+      { minLength: 0, maxLength: 4 },
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Property 1 — Every emitted slot is fully inside window
+// ---------------------------------------------------------------------------
+
+describe("Property 1: every slot is fully inside window", () => {
+  it("holds for ≥200 cases", () => {
+    fc.assert(
+      fc.property(availabilityRuleArb, windowArb, ianaZoneArb, (r, win, renderZone) => {
+        const slots = generateSlots({
+          rules: [r],
+          busy: [],
+          window: win,
+          providerZone: r.zone,
+          renderZone,
+        });
+        for (const s of slots) {
+          const slotEnd = s.startUtc.plus({ minutes: s.durationMinutes });
+          if (s.startUtc < win.startUtc) return false;
+          if (slotEnd > win.endUtc) return false;
+        }
+        return true;
+      }),
+      { numRuns: 200 },
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Property 2 — Every slot is disjoint from every busy block (touching OK)
+// ---------------------------------------------------------------------------
+
+describe("Property 2: every slot is disjoint from busy blocks (touching allowed)", () => {
+  it("holds for ≥200 cases", () => {
+    fc.assert(
+      fc.property(
+        availabilityRuleArb,
+        windowArb.chain((win) =>
+          busyBlocksArb(win).map((blocks) => ({ win, blocks })),
+        ),
+        ianaZoneArb,
+        (r, { win, blocks }, renderZone) => {
+          const slots = generateSlots({
+            rules: [r],
+            busy: blocks,
+            window: win,
+            providerZone: r.zone,
+            renderZone,
+          });
+          for (const s of slots) {
+            const slotEnd = s.startUtc.plus({ minutes: s.durationMinutes });
+            for (const b of blocks) {
+              // overlap iff startUtc < b.endUtc && slotEnd > b.startUtc
+              const overlaps =
+                s.startUtc < b.endUtc && slotEnd > b.startUtc;
+              if (overlaps) return false;
+            }
+          }
+          return true;
+        },
+      ),
+      { numRuns: 200 },
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Property 3 — Slot starts align to grid relative to rule.start_local
+// ---------------------------------------------------------------------------
+
+describe("Property 3: slot starts align to (slot+buffer) grid relative to start_local", () => {
+  it("holds for ≥200 cases", () => {
+    fc.assert(
+      fc.property(availabilityRuleArb, windowArb, ianaZoneArb, (r, win, renderZone) => {
+        const slots = generateSlots({
+          rules: [r],
+          busy: [],
+          window: win,
+          providerZone: r.zone,
+          renderZone,
+        });
+        const gridMinutes = r.slot_minutes + r.buffer_minutes;
+        for (const s of slots) {
+          // Convert slot start to provider zone
+          const localStart = s.startUtc.setZone(r.zone);
+          // Minutes from midnight on that day
+          const minutesFromMidnight = localStart.hour * 60 + localStart.minute;
+          // Offset from rule.start_local
+          const offset = minutesFromMidnight - r.start_local;
+          if (offset < 0) return false;
+          if (gridMinutes > 0 && offset % gridMinutes !== 0) return false;
+        }
+        return true;
+      }),
+      { numRuns: 200 },
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Property 4 — Slot count is monotonically non-increasing in |busy|
+// ---------------------------------------------------------------------------
+
+describe("Property 4: slot count is non-increasing as busy grows", () => {
+  it("holds for ≥200 cases", () => {
+    fc.assert(
+      fc.property(
+        availabilityRuleArb,
+        windowArb,
+        ianaZoneArb,
+        (r, win, renderZone) => {
+          // Generate slots with no busy
+          const allSlots = generateSlots({
+            rules: [r],
+            busy: [],
+            window: win,
+            providerZone: r.zone,
+            renderZone,
+          });
+
+          if (allSlots.length === 0) return true; // nothing to test
+
+          // Pick first slot as a busy block, count must drop or stay same
+          const firstSlot = allSlots[0];
+          const blocker = busy(
+            firstSlot.startUtc,
+            firstSlot.startUtc.plus({ minutes: firstSlot.durationMinutes }),
+          );
+
+          const fewerSlots = generateSlots({
+            rules: [r],
+            busy: [blocker],
+            window: win,
+            providerZone: r.zone,
+            renderZone,
+          });
+
+          return fewerSlots.length <= allSlots.length;
+        },
+      ),
+      { numRuns: 200 },
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Property 5 — Slot list is identical regardless of renderZone
+// ---------------------------------------------------------------------------
+
+describe("Property 5: slot list is identical regardless of renderZone", () => {
+  it("holds for ≥200 cases", () => {
+    fc.assert(
+      fc.property(
+        availabilityRuleArb,
+        windowArb,
+        ianaZoneArb,
+        ianaZoneArb,
+        (r, win, zone1, zone2) => {
+          const slots1 = generateSlots({
+            rules: [r],
+            busy: [],
+            window: win,
+            providerZone: r.zone,
+            renderZone: zone1,
+          });
+          const slots2 = generateSlots({
+            rules: [r],
+            busy: [],
+            window: win,
+            providerZone: r.zone,
+            renderZone: zone2,
+          });
+
+          if (slots1.length !== slots2.length) return false;
+          for (let i = 0; i < slots1.length; i++) {
+            if (slots1[i].startUtc.toMillis() !== slots2[i].startUtc.toMillis()) return false;
+            if (slots1[i].durationMinutes !== slots2[i].durationMinutes) return false;
+          }
+          return true;
+        },
+      ),
+      { numRuns: 200 },
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Property 6 — No slot starts inside a DST gap
+// ---------------------------------------------------------------------------
+
+describe("Property 6: no slot starts inside a DST gap", () => {
+  it("holds for ≥200 cases with gap-prone zones", () => {
+    // Use zones known to have DST gaps; test over spring-forward dates.
+    const gapZoneArb = fc.constantFrom(
+      "America/New_York",
+      "America/Los_Angeles",
+      "America/Chicago",
+      "Europe/Madrid",
+      "Europe/London",
+    );
+
+    // Windows around spring-forward transitions
+    const springWindowArb = fc.constantFrom(
+      // US 2025 spring forward Mar 9
+      {
+        startUtc: DateTime.fromISO("2025-03-09T05:00:00Z"),
+        endUtc: DateTime.fromISO("2025-03-09T09:00:00Z"),
+      },
+      // US 2026 spring forward Mar 8
+      {
+        startUtc: DateTime.fromISO("2026-03-08T05:00:00Z"),
+        endUtc: DateTime.fromISO("2026-03-08T09:00:00Z"),
+      },
+      // EU 2026 spring forward Mar 29
+      {
+        startUtc: DateTime.fromISO("2026-03-29T00:00:00Z"),
+        endUtc: DateTime.fromISO("2026-03-29T04:00:00Z"),
+      },
+    );
+
+    fc.assert(
+      fc.property(
+        fc.tuple(availabilityRuleArb, gapZoneArb, springWindowArb).map(([r, zone, win]) => ({
+          r: { ...r, zone, weekday: win.startUtc.setZone(zone).weekday as 1|2|3|4|5|6|7 },
+          zone,
+          win,
+        })),
+        ({ r, zone, win }) => {
+          const slots = generateSlots({
+            rules: [r],
+            busy: [],
+            window: win,
+            providerZone: zone,
+            renderZone: zone,
+          });
+
+          for (const s of slots) {
+            const local = s.startUtc.setZone(zone);
+            // A time in a gap is invalid in Luxon when constructed via fromObject
+            const reconstructed = DateTime.fromObject(
+              { year: local.year, month: local.month, day: local.day, hour: local.hour, minute: local.minute },
+              { zone },
+            );
+            // If the reconstructed time is invalid or has been shifted (gap),
+            // its UTC offset would differ from a non-gap time
+            if (!reconstructed.isValid) return false;
+            // Check the slot's UTC time matches reconstruction — if in gap, Luxon
+            // will shift the time forward, so UTC instants won't match
+            if (reconstructed.toUTC().toMillis() !== s.startUtc.toMillis()) return false;
+          }
+          return true;
+        },
+      ),
+      { numRuns: 200 },
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Property 7 — Fall-back fold: exactly one slot per fold instant
+// ---------------------------------------------------------------------------
+
+describe("Property 7: fall-back fold hour yields exactly one slot per UTC instant", () => {
+  it("holds: fold wall-clock time appears at most once in slot list", () => {
+    // US fall-back 2025: Nov 2, clocks go back at 2am ET → 1am ET again
+    // America/New_York falls back at 2025-11-02T06:00:00Z (2am → 1am)
+    const win = {
+      startUtc: DateTime.fromISO("2025-11-02T04:00:00Z"),
+      endUtc: DateTime.fromISO("2025-11-02T10:00:00Z"),
+    };
+
+    // Rule: every Sunday, 0:00 to 23:59 (covers the fold window), 30-min slots, 0 buffer
+    const r: AvailabilityRule = {
+      weekday: 7, // Sunday
+      start_local: 0,
+      end_local: 23 * 60 + 59,
+      slot_minutes: 30,
+      buffer_minutes: 0,
+      zone: "America/New_York",
+      valid_from: null,
+      valid_to: null,
+    };
+
+    const slots = generateSlots({
+      rules: [r],
+      busy: [],
+      window: win,
+      providerZone: "America/New_York",
+      renderZone: "America/New_York",
+    });
+
+    // In a fold, the local wall-clock time 1:00 AM can map to two different UTC instants.
+    // We must emit exactly ONE slot per UTC instant (deduplicated by UTC).
+    const utcMillis = slots.map((s) => s.startUtc.toMillis());
+    const uniqueUtcMillis = new Set(utcMillis);
+    expect(utcMillis.length).toBe(uniqueUtcMillis.size);
+
+    // Additionally, the property-based version
+    fc.assert(
+      fc.property(
+        fc.constantFrom("America/New_York", "America/Chicago", "America/Los_Angeles"),
+        (zone) => {
+          // Fall-back windows for each zone
+          const fallbacks: Record<string, { startUtc: string; endUtc: string }> = {
+            "America/New_York": { startUtc: "2025-11-02T04:00:00Z", endUtc: "2025-11-02T10:00:00Z" },
+            "America/Chicago": { startUtc: "2025-11-02T05:00:00Z", endUtc: "2025-11-02T10:00:00Z" },
+            "America/Los_Angeles": { startUtc: "2025-11-02T07:00:00Z", endUtc: "2025-11-02T12:00:00Z" },
+          };
+          const fb = fallbacks[zone];
+          const foldWin = {
+            startUtc: DateTime.fromISO(fb.startUtc),
+            endUtc: DateTime.fromISO(fb.endUtc),
+          };
+          const foldRule: AvailabilityRule = {
+            weekday: 7,
+            start_local: 0,
+            end_local: 23 * 60 + 59,
+            slot_minutes: 30,
+            buffer_minutes: 0,
+            zone,
+            valid_from: null,
+            valid_to: null,
+          };
+          const foldSlots = generateSlots({
+            rules: [foldRule],
+            busy: [],
+            window: foldWin,
+            providerZone: zone,
+            renderZone: zone,
+          });
+          const ms = foldSlots.map((s) => s.startUtc.toMillis());
+          return ms.length === new Set(ms).size;
+        },
+      ),
+      { numRuns: 200 },
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Property 8 — Overlapping rules with same weekday → throws
+// ---------------------------------------------------------------------------
+
+describe("Property 8: overlapping rules with same weekday throw", () => {
+  it("throws when two rules for the same weekday have overlapping time ranges", () => {
+    fc.assert(
+      fc.property(
+        availabilityRuleArb,
+        ianaZoneArb,
+        (r, renderZone) => {
+          // Create a second rule that overlaps: same weekday, same zone, start_local shifted by 30 min
+          const r2: AvailabilityRule = {
+            ...r,
+            start_local: r.start_local + 30,
+            end_local: r.end_local + 30,
+          };
+          const win = {
+            startUtc: DateTime.fromISO("2025-01-01T00:00:00Z"),
+            endUtc: DateTime.fromISO("2025-01-15T00:00:00Z"),
+          };
+          let threw = false;
+          try {
+            generateSlots({
+              rules: [r, r2],
+              busy: [],
+              window: win,
+              providerZone: r.zone,
+              renderZone,
+            });
+          } catch {
+            threw = true;
+          }
+          return threw;
+        },
+      ),
+      { numRuns: 200 },
+    );
+  });
+
+  it("does NOT throw when rules have different weekdays", () => {
+    fc.assert(
+      fc.property(
+        availabilityRuleArb,
+        ianaZoneArb,
+        (r, renderZone) => {
+          const otherWeekday = ((r.weekday % 7) + 1) as 1 | 2 | 3 | 4 | 5 | 6 | 7;
+          const r2: AvailabilityRule = {
+            ...r,
+            weekday: otherWeekday,
+          };
+          const win = {
+            startUtc: DateTime.fromISO("2025-01-01T00:00:00Z"),
+            endUtc: DateTime.fromISO("2025-01-15T00:00:00Z"),
+          };
+          let threw = false;
+          try {
+            generateSlots({
+              rules: [r, r2],
+              busy: [],
+              window: win,
+              providerZone: r.zone,
+              renderZone,
+            });
+          } catch {
+            threw = true;
+          }
+          return !threw;
+        },
+      ),
+      { numRuns: 200 },
+    );
+  });
+});
+
+// ===========================================================================
+// FIXED-CASE FIXTURES
+// ===========================================================================
+
+// ---------------------------------------------------------------------------
+// Fixture: US DST spring-forward — gap slot omitted
+// ---------------------------------------------------------------------------
+
+describe("Fixture: US DST spring-forward gap slot omitted", () => {
+  // Mar 9 2025: America/New_York clocks spring forward at 2am → 3am
+  // Gap: 2:00am–2:59am ET does not exist on Mar 9 2025.
+  // UTC: 2025-03-09T07:00:00Z (= 2:00am ET) through 07:59Z is the gap.
+  it("omits slots in the 2am gap on Mar 9 2025 (NY spring forward)", () => {
+    const r: AvailabilityRule = {
+      weekday: 7, // Sunday Mar 9 2025
+      start_local: 0,
+      end_local: 24 * 60,
+      slot_minutes: 30,
+      buffer_minutes: 0,
+      zone: "America/New_York",
+      valid_from: null,
+      valid_to: null,
+    };
+    const win = {
+      startUtc: DateTime.fromISO("2025-03-09T00:00:00Z"),
+      endUtc: DateTime.fromISO("2025-03-09T12:00:00Z"),
+    };
+    const slots = generateSlots({
+      rules: [r],
+      busy: [],
+      window: win,
+      providerZone: "America/New_York",
+      renderZone: "America/New_York",
+    });
+
+    // No slot should start at a UTC time that falls in the gap.
+    // Gap in UTC: 07:00Z to 07:59Z (2am–2:59am ET, which don't exist)
+    for (const s of slots) {
+      const utcHour = s.startUtc.toUTC().hour;
+      const utcMin = s.startUtc.toUTC().minute;
+      const utcMinutes = utcHour * 60 + utcMin;
+      // 07:00Z–07:59Z is the gap
+      expect(utcMinutes >= 7 * 60 && utcMinutes < 8 * 60).toBe(false);
+    }
+  });
+
+  it("omits slots in the 2am gap on Mar 8 2026 (NY spring forward)", () => {
+    const r: AvailabilityRule = {
+      weekday: 7, // Sunday Mar 8 2026
+      start_local: 0,
+      end_local: 24 * 60,
+      slot_minutes: 30,
+      buffer_minutes: 0,
+      zone: "America/New_York",
+      valid_from: null,
+      valid_to: null,
+    };
+    const win = {
+      startUtc: DateTime.fromISO("2026-03-08T00:00:00Z"),
+      endUtc: DateTime.fromISO("2026-03-08T12:00:00Z"),
+    };
+    const slots = generateSlots({
+      rules: [r],
+      busy: [],
+      window: win,
+      providerZone: "America/New_York",
+      renderZone: "America/New_York",
+    });
+
+    for (const s of slots) {
+      const utcHour = s.startUtc.toUTC().hour;
+      const utcMin = s.startUtc.toUTC().minute;
+      const utcMinutes = utcHour * 60 + utcMin;
+      expect(utcMinutes >= 7 * 60 && utcMinutes < 8 * 60).toBe(false);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fixture: US DST fall-back — fold hour offered exactly once
+// ---------------------------------------------------------------------------
+
+describe("Fixture: US DST fall-back fold hour offered exactly once", () => {
+  // Nov 2 2025: America/New_York clocks fall back at 2am → 1am
+  // UTC: 06:00Z is 2am EDT; after fallback, 06:00Z is 1am EST... wait:
+  // EDT = UTC-4; EST = UTC-5
+  // 1:00am EDT = 05:00Z; 2:00am EDT = 06:00Z → clocks go back → 1:00am EST = 06:00Z
+  // So 1:00am–1:59am local appears twice in UTC: 05:00Z–05:59Z and 06:00Z–06:59Z
+
+  it("offers the 1am fold hour exactly once on Nov 2 2025", () => {
+    const r: AvailabilityRule = {
+      weekday: 7, // Sunday Nov 2 2025
+      start_local: 0,
+      end_local: 24 * 60,
+      slot_minutes: 60,
+      buffer_minutes: 0,
+      zone: "America/New_York",
+      valid_from: null,
+      valid_to: null,
+    };
+    const win = {
+      startUtc: DateTime.fromISO("2025-11-02T04:00:00Z"), // midnight ET
+      endUtc: DateTime.fromISO("2025-11-02T10:00:00Z"),   // 5am ET (post-fold)
+    };
+    const slots = generateSlots({
+      rules: [r],
+      busy: [],
+      window: win,
+      providerZone: "America/New_York",
+      renderZone: "America/New_York",
+    });
+
+    // Count distinct UTC start instants — should all be unique
+    const utcMillis = slots.map((s) => s.startUtc.toMillis());
+    expect(new Set(utcMillis).size).toBe(utcMillis.length);
+
+    // The fold window has 6 UTC hours but only 5 distinct wall-clock hours
+    // (midnight, 1am[first], 1am[second=fold], 2am, 3am, 4am)
+    // With 60-min slots covering that window, we should get exactly 6 slots
+    // (one per UTC hour) but NOT two at the same wall-clock 1am.
+    // Actually the spec says offer the fold hour ONCE. So there should NOT
+    // be two slots with local time 1:00am. They would differ by UTC instant.
+    const localOneAM = slots.filter((s) => {
+      const local = s.startUtc.setZone("America/New_York");
+      return local.hour === 1 && local.minute === 0;
+    });
+    expect(localOneAM.length).toBeLessThanOrEqual(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fixture: Madrid provider + NYC booker, Mar 8–29 2026 (US DST started, EU not)
+// ---------------------------------------------------------------------------
+
+describe("Fixture: Madrid provider + NYC booker, US/EU DST divergence window", () => {
+  // Mar 8 2026: US clocks spring forward (UTC-5 → UTC-4 for NY)
+  // Mar 29 2026: EU clocks spring forward (UTC+1 → UTC+2 for Madrid)
+  // Between Mar 8–29: NY is UTC-4, Madrid is UTC+1 (5h gap instead of 6h)
+
+  it("generates correct UTC slots for Madrid rule, renderable in NYC zone", () => {
+    // Daniel: Mon–Fri, 9am–5pm Europe/Madrid, 60-min slots, 0 buffer
+    // On Mar 10 2026 (Tuesday, US DST started, EU DST not yet):
+    // Madrid is UTC+1; 9am CET = 08:00Z, 5pm CET = 16:00Z → 8 slots
+    const r: AvailabilityRule = {
+      weekday: 2, // Tuesday
+      start_local: 9 * 60,
+      end_local: 17 * 60,
+      slot_minutes: 60,
+      buffer_minutes: 0,
+      zone: "Europe/Madrid",
+      valid_from: null,
+      valid_to: null,
+    };
+    const win = {
+      startUtc: DateTime.fromISO("2026-03-10T00:00:00Z"),
+      endUtc: DateTime.fromISO("2026-03-11T00:00:00Z"),
+    };
+
+    const slotsNYC = generateSlots({
+      rules: [r],
+      busy: [],
+      window: win,
+      providerZone: "Europe/Madrid",
+      renderZone: "America/New_York",
+    });
+
+    const slotsMadrid = generateSlots({
+      rules: [r],
+      busy: [],
+      window: win,
+      providerZone: "Europe/Madrid",
+      renderZone: "Europe/Madrid",
+    });
+
+    // renderZone must not affect UTC times
+    expect(slotsNYC.length).toBe(slotsMadrid.length);
+    for (let i = 0; i < slotsNYC.length; i++) {
+      expect(slotsNYC[i].startUtc.toMillis()).toBe(slotsMadrid[i].startUtc.toMillis());
+    }
+
+    // 8 slots: 8Z, 9Z, 10Z, 11Z, 12Z, 13Z, 14Z, 15Z (9am–4pm CET, last slot 4pm, ends 5pm)
+    expect(slotsNYC.length).toBe(8);
+
+    // First slot in NYC should be 4am EDT (UTC-4 = 08Z - 4 = 4am)
+    const firstLocal = slotsNYC[0].startUtc.setZone("America/New_York");
+    expect(firstLocal.hour).toBe(4);
+    expect(firstLocal.offset).toBe(-4 * 60); // EDT = UTC-4
+  });
+
+  it("renders correctly around EU DST start Mar 29 2026", () => {
+    // Mar 29 2026: Madrid springs forward at 2am → 3am (gap 2am–2:59am)
+    // A rule that covers that gap should omit the gap slot
+    const r: AvailabilityRule = {
+      weekday: 7, // Sunday Mar 29 2026
+      start_local: 1 * 60, // 1am
+      end_local: 4 * 60,   // 4am
+      slot_minutes: 30,
+      buffer_minutes: 0,
+      zone: "Europe/Madrid",
+      valid_from: null,
+      valid_to: null,
+    };
+    const win = {
+      startUtc: DateTime.fromISO("2026-03-29T00:00:00Z"),
+      endUtc: DateTime.fromISO("2026-03-29T05:00:00Z"),
+    };
+    const slots = generateSlots({
+      rules: [r],
+      busy: [],
+      window: win,
+      providerZone: "Europe/Madrid",
+      renderZone: "America/New_York",
+    });
+
+    // Slots at 2am Madrid local (which is in the gap) must not appear.
+    for (const s of slots) {
+      const local = s.startUtc.setZone("Europe/Madrid");
+      // 2:00–2:59am CET does not exist on Mar 29
+      const gapStart = DateTime.fromObject({ year: 2026, month: 3, day: 29, hour: 2, minute: 0 }, { zone: "Europe/Madrid" });
+      // If in gap, Luxon will return invalid or shift to 3am. Verify no slot
+      // has a local time in that gap range.
+      if (local.hour === 2) {
+        // This would be in the gap — should never happen
+        expect(true).toBe(false); // fail the test
+      }
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fixture: Leap day Feb 29 2024
+// ---------------------------------------------------------------------------
+
+describe("Fixture: leap day Feb 29 2024", () => {
+  it("generates slots on Feb 29 2024 (Thursday)", () => {
+    const r: AvailabilityRule = {
+      weekday: 4, // Thursday
+      start_local: 9 * 60,
+      end_local: 17 * 60,
+      slot_minutes: 60,
+      buffer_minutes: 0,
+      zone: "America/New_York",
+      valid_from: null,
+      valid_to: null,
+    };
+    const win = {
+      startUtc: DateTime.fromISO("2024-02-29T00:00:00Z"),
+      endUtc: DateTime.fromISO("2024-03-01T00:00:00Z"),
+    };
+    const slots = generateSlots({
+      rules: [r],
+      busy: [],
+      window: win,
+      providerZone: "America/New_York",
+      renderZone: "America/New_York",
+    });
+
+    // 9am–4pm ET (8 slots), NY is EST (UTC-5) in Feb 29 2024
+    // 9am EST = 14Z, last slot 4pm EST starts at 21Z
+    expect(slots.length).toBe(8);
+    const firstLocal = slots[0].startUtc.setZone("America/New_York");
+    expect(firstLocal.year).toBe(2024);
+    expect(firstLocal.month).toBe(2);
+    expect(firstLocal.day).toBe(29);
+    expect(firstLocal.hour).toBe(9);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fixture: Year boundary Dec 31 → Jan 1
+// ---------------------------------------------------------------------------
+
+describe("Fixture: year boundary Dec 31 → Jan 1", () => {
+  it("generates slots across Dec 31 2025 and Jan 1 2026", () => {
+    // Mon–Fri rule, covers both Wed Dec 31 and Thu Jan 1
+    const rWed: AvailabilityRule = {
+      weekday: 3, // Wednesday
+      start_local: 10 * 60,
+      end_local: 14 * 60,
+      slot_minutes: 60,
+      buffer_minutes: 0,
+      zone: "UTC",
+      valid_from: null,
+      valid_to: null,
+    };
+    const rThu: AvailabilityRule = {
+      weekday: 4, // Thursday
+      start_local: 10 * 60,
+      end_local: 14 * 60,
+      slot_minutes: 60,
+      buffer_minutes: 0,
+      zone: "UTC",
+      valid_from: null,
+      valid_to: null,
+    };
+    const win = {
+      startUtc: DateTime.fromISO("2025-12-31T00:00:00Z"),
+      endUtc: DateTime.fromISO("2026-01-02T00:00:00Z"),
+    };
+    const slots = generateSlots({
+      rules: [rWed, rThu],
+      busy: [],
+      window: win,
+      providerZone: "UTC",
+      renderZone: "UTC",
+    });
+
+    // 4 slots on Dec 31 (10, 11, 12, 13 UTC) + 4 slots on Jan 1 = 8
+    expect(slots.length).toBe(8);
+
+    const dec31Slots = slots.filter((s) => s.startUtc.setZone("UTC").day === 31);
+    const jan1Slots = slots.filter((s) => s.startUtc.setZone("UTC").day === 1);
+    expect(dec31Slots.length).toBe(4);
+    expect(jan1Slots.length).toBe(4);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fixture: ISO week boundary
+// ---------------------------------------------------------------------------
+
+describe("Fixture: ISO week boundary (Mon at start of new week)", () => {
+  it("correctly handles a window spanning two ISO weeks", () => {
+    // Jan 5 2025 is Sunday (last day of ISO week 1)
+    // Jan 6 2025 is Monday (first day of ISO week 2)
+    const rSun: AvailabilityRule = {
+      weekday: 7, // Sunday
+      start_local: 10 * 60,
+      end_local: 12 * 60,
+      slot_minutes: 60,
+      buffer_minutes: 0,
+      zone: "UTC",
+      valid_from: null,
+      valid_to: null,
+    };
+    const rMon: AvailabilityRule = {
+      weekday: 1, // Monday
+      start_local: 10 * 60,
+      end_local: 12 * 60,
+      slot_minutes: 60,
+      buffer_minutes: 0,
+      zone: "UTC",
+      valid_from: null,
+      valid_to: null,
+    };
+    const win = {
+      startUtc: DateTime.fromISO("2025-01-05T00:00:00Z"),
+      endUtc: DateTime.fromISO("2025-01-07T00:00:00Z"),
+    };
+    const slots = generateSlots({
+      rules: [rSun, rMon],
+      busy: [],
+      window: win,
+      providerZone: "UTC",
+      renderZone: "UTC",
+    });
+
+    // 2 slots Sunday + 2 slots Monday = 4
+    expect(slots.length).toBe(4);
+
+    const sunSlots = slots.filter((s) => s.startUtc.setZone("UTC").weekday === 7);
+    const monSlots = slots.filter((s) => s.startUtc.setZone("UTC").weekday === 1);
+    expect(sunSlots.length).toBe(2);
+    expect(monSlots.length).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fixture: Pacific/Apia skipped-day weirdness (stretch)
+// ---------------------------------------------------------------------------
+
+describe("Fixture: Pacific/Apia skipped day (stretch)", () => {
+  // In December 2011, Samoa skipped Dec 30 entirely (UTC+14 zone).
+  // For v0.1 we just verify no crash and no slots land on the skipped day.
+  // The rule below runs "Fridays" — Dec 29 2023 is a Friday in Pacific/Apia.
+  it("generates slots in Pacific/Apia without crashing", () => {
+    const r: AvailabilityRule = {
+      weekday: 5, // Friday
+      start_local: 9 * 60,
+      end_local: 17 * 60,
+      slot_minutes: 60,
+      buffer_minutes: 0,
+      zone: "Pacific/Apia",
+      valid_from: null,
+      valid_to: null,
+    };
+    const win = {
+      startUtc: DateTime.fromISO("2023-12-28T00:00:00Z"),
+      endUtc: DateTime.fromISO("2023-12-30T00:00:00Z"),
+    };
+
+    let threw = false;
+    let slots: Slot[] = [];
+    try {
+      slots = generateSlots({
+        rules: [r],
+        busy: [],
+        window: win,
+        providerZone: "Pacific/Apia",
+        renderZone: "UTC",
+      });
+    } catch {
+      threw = true;
+    }
+
+    expect(threw).toBe(false);
+    // All slots must be valid
+    for (const s of slots) {
+      expect(s.startUtc.isValid).toBe(true);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fixture: Buffer-applied-after grid alignment — Maya's "50/10"
+// ---------------------------------------------------------------------------
+
+describe("Fixture: buffer applied AFTER session (Maya 50/10 → 60-min grid, 6 slots/day)", () => {
+  // Maya: Tue/Thu 10am–4pm America/Los_Angeles, 50-min sessions, 10-min buffer after.
+  // Grid = 50 + 10 = 60 min. Start 10am. Slots: 10:00, 11:00, 12:00, 1:00, 2:00, 3:00 → 6 slots.
+  // Last slot starts 3pm, ends 3:50pm + 10 buffer = 4pm — fits exactly.
+
+  it("produces exactly 6 slots per day on Tue/Thu 10am–4pm LA with 50/10", () => {
+    const rTue: AvailabilityRule = {
+      weekday: 2, // Tuesday
+      start_local: 10 * 60,
+      end_local: 16 * 60,
+      slot_minutes: 50,
+      buffer_minutes: 10,
+      zone: "America/Los_Angeles",
+      valid_from: null,
+      valid_to: null,
+    };
+    const rThu: AvailabilityRule = {
+      weekday: 4, // Thursday
+      start_local: 10 * 60,
+      end_local: 16 * 60,
+      slot_minutes: 50,
+      buffer_minutes: 10,
+      zone: "America/Los_Angeles",
+      valid_from: null,
+      valid_to: null,
+    };
+
+    // A week in March (no DST transition)
+    // Mar 11 2025 = Tuesday, Mar 13 2025 = Thursday (LA is PST = UTC-8 in early March 2025)
+    // Wait — US DST starts Mar 9 2025, so Mar 11 is PDT (UTC-7).
+    const win = {
+      startUtc: DateTime.fromISO("2025-03-11T00:00:00Z"),
+      endUtc: DateTime.fromISO("2025-03-14T00:00:00Z"),
+    };
+
+    const slots = generateSlots({
+      rules: [rTue, rThu],
+      busy: [],
+      window: win,
+      providerZone: "America/Los_Angeles",
+      renderZone: "America/Los_Angeles",
+    });
+
+    const tuesdaySlots = slots.filter((s) => {
+      const local = s.startUtc.setZone("America/Los_Angeles");
+      return local.weekday === 2;
+    });
+    const thursdaySlots = slots.filter((s) => {
+      const local = s.startUtc.setZone("America/Los_Angeles");
+      return local.weekday === 4;
+    });
+
+    expect(tuesdaySlots.length).toBe(6);
+    expect(thursdaySlots.length).toBe(6);
+
+    // Verify grid alignment: each slot starts on a 60-min boundary from 10am
+    for (const s of tuesdaySlots) {
+      const local = s.startUtc.setZone("America/Los_Angeles");
+      const minutesFrom10am = (local.hour * 60 + local.minute) - 10 * 60;
+      expect(minutesFrom10am >= 0).toBe(true);
+      expect(minutesFrom10am % 60).toBe(0);
+    }
+
+    // Verify duration is 50 minutes (buffer is NOT part of the slot duration)
+    for (const s of slots) {
+      expect(s.durationMinutes).toBe(50);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fixture: Overlapping availability rules → throws
+// ---------------------------------------------------------------------------
+
+describe("Fixture: overlapping availability rules throw", () => {
+  it("throws when two rules overlap on the same weekday", () => {
+    const r1: AvailabilityRule = {
+      weekday: 2, // Tuesday
+      start_local: 9 * 60,
+      end_local: 13 * 60,
+      slot_minutes: 60,
+      buffer_minutes: 0,
+      zone: "America/New_York",
+      valid_from: null,
+      valid_to: null,
+    };
+    const r2: AvailabilityRule = {
+      weekday: 2, // Tuesday — overlaps 10am–1pm
+      start_local: 10 * 60,
+      end_local: 14 * 60,
+      slot_minutes: 60,
+      buffer_minutes: 0,
+      zone: "America/New_York",
+      valid_from: null,
+      valid_to: null,
+    };
+    const win = {
+      startUtc: DateTime.fromISO("2025-01-01T00:00:00Z"),
+      endUtc: DateTime.fromISO("2025-01-15T00:00:00Z"),
+    };
+
+    expect(() =>
+      generateSlots({
+        rules: [r1, r2],
+        busy: [],
+        window: win,
+        providerZone: "America/New_York",
+        renderZone: "America/New_York",
+      }),
+    ).toThrow();
+  });
+
+  it("does NOT throw for adjacent (non-overlapping) rules on the same weekday", () => {
+    const r1: AvailabilityRule = {
+      weekday: 2,
+      start_local: 9 * 60,
+      end_local: 12 * 60,
+      slot_minutes: 60,
+      buffer_minutes: 0,
+      zone: "America/New_York",
+      valid_from: null,
+      valid_to: null,
+    };
+    const r2: AvailabilityRule = {
+      weekday: 2,
+      start_local: 12 * 60, // starts exactly when r1 ends — touching, not overlapping
+      end_local: 15 * 60,
+      slot_minutes: 60,
+      buffer_minutes: 0,
+      zone: "America/New_York",
+      valid_from: null,
+      valid_to: null,
+    };
+    const win = {
+      startUtc: DateTime.fromISO("2025-01-01T00:00:00Z"),
+      endUtc: DateTime.fromISO("2025-01-15T00:00:00Z"),
+    };
+
+    expect(() =>
+      generateSlots({
+        rules: [r1, r2],
+        busy: [],
+        window: win,
+        providerZone: "America/New_York",
+        renderZone: "America/New_York",
+      }),
+    ).not.toThrow();
+  });
+});

--- a/tests/unit/slot-gen.test.ts
+++ b/tests/unit/slot-gen.test.ts
@@ -1181,132 +1181,90 @@ describe("validateRules — date-bounded rule overlap", () => {
     endUtc: DateTime.fromISO("2025-08-01T00:00:00Z"),
   };
 
-  it(
-    "does NOT throw for same weekday + overlapping time windows + non-overlapping date ranges " +
-      "(SPEC §Availability rule semantics: 'normal Tuesdays 10–4 except July when 12–4')",
-    () => {
-      // Rule A: Tuesdays 10am–4pm, effective Jan 1–Jun 30
-      const rA = rule(
-        2, // Tuesday
-        10,
-        16,
-        60,
-        0,
-        NYC,
-        dt(NYC, 2025, 1, 1, 0),
-        dt(NYC, 2025, 6, 30, 23, 59),
-      );
-      // Rule B: Tuesdays 12pm–4pm, effective Jul 1–Dec 31
-      // Time windows overlap (12–16 is inside 10–16), but date ranges do not.
-      const rB = rule(
-        2, // Tuesday
-        12,
-        16,
-        60,
-        0,
-        NYC,
-        dt(NYC, 2025, 7, 1, 0),
-        dt(NYC, 2025, 12, 31, 23, 59),
-      );
-
-      expect(() =>
-        generateSlots({
-          rules: [rA, rB],
-          busy: [],
-          window: win,
-          providerZone: NYC,
-          renderZone: NYC,
-        }),
-      ).not.toThrow();
-    },
-  );
-
-  it(
-    "emits slots from the correct rule for each date period " +
-      "(Jun Tuesdays get 10am–4pm, Jul Tuesdays get 12pm–4pm)",
-    () => {
-      const rA = rule(
-        2,
-        10,
-        16,
-        60,
-        0,
-        NYC,
-        dt(NYC, 2025, 1, 1, 0),
-        dt(NYC, 2025, 6, 30, 23, 59),
-      );
-      const rB = rule(
-        2,
-        12,
-        16,
-        60,
-        0,
-        NYC,
-        dt(NYC, 2025, 7, 1, 0),
-        dt(NYC, 2025, 12, 31, 23, 59),
-      );
-
-      const slots = generateSlots({
-        rules: [rA, rB],
-        busy: [],
-        window: win,
-        providerZone: NYC,
-        renderZone: NYC,
-      });
-
-      // Jun Tuesdays (2025-06-03, 2025-06-10, 2025-06-17, 2025-06-24): 6 slots each = 24
-      // Jul Tuesdays (2025-07-01, 2025-07-08, 2025-07-15, 2025-07-22, 2025-07-29): 4 slots each = 20
-      const junTuesdaySlots = slots.filter((s) => {
-        const local = s.startUtc.setZone(NYC);
-        return local.month === 6 && local.weekday === 2;
-      });
-      const julTuesdaySlots = slots.filter((s) => {
-        const local = s.startUtc.setZone(NYC);
-        return local.month === 7 && local.weekday === 2;
-      });
-
-      // Jun rule: 10am–4pm, 60-min slots → 6 slots per Tuesday
-      expect(junTuesdaySlots.length).toBe(4 * 6); // 4 Jun Tuesdays × 6 slots
-
-      // Jul rule: 12pm–4pm, 60-min slots → 4 slots per Tuesday
-      expect(julTuesdaySlots.length).toBe(5 * 4); // 5 Jul Tuesdays × 4 slots
-
-      // Jun slots should NOT start before 10am local
-      for (const s of junTuesdaySlots) {
-        const local = s.startUtc.setZone(NYC);
-        expect(local.hour).toBeGreaterThanOrEqual(10);
-      }
-
-      // Jul slots should NOT start before 12pm local
-      for (const s of julTuesdaySlots) {
-        const local = s.startUtc.setZone(NYC);
-        expect(local.hour).toBeGreaterThanOrEqual(12);
-      }
-    },
-  );
-
-  it("STILL throws for same weekday + overlapping time windows + overlapping date ranges", () => {
-    // Both rules active for the same date range — conflict
+  it("does NOT throw for same weekday + overlapping time windows + non-overlapping date ranges " +
+    "(SPEC §Availability rule semantics: 'normal Tuesdays 10–4 except July when 12–4')", () => {
+    // Rule A: Tuesdays 10am–4pm, effective Jan 1–Jun 30
     const rA = rule(
-      2,
+      2, // Tuesday
       10,
       16,
       60,
       0,
       NYC,
-      dt(NYC, 2025, 6, 1, 0),
-      dt(NYC, 2025, 8, 31, 23, 59),
+      dt(NYC, 2025, 1, 1, 0),
+      dt(NYC, 2025, 6, 30, 23, 59),
     );
+    // Rule B: Tuesdays 12pm–4pm, effective Jul 1–Dec 31
+    // Time windows overlap (12–16 is inside 10–16), but date ranges do not.
     const rB = rule(
-      2,
+      2, // Tuesday
       12,
-      18,
+      16,
       60,
       0,
       NYC,
       dt(NYC, 2025, 7, 1, 0),
-      dt(NYC, 2025, 9, 30, 23, 59),
+      dt(NYC, 2025, 12, 31, 23, 59),
     );
+
+    expect(() =>
+      generateSlots({
+        rules: [rA, rB],
+        busy: [],
+        window: win,
+        providerZone: NYC,
+        renderZone: NYC,
+      }),
+    ).not.toThrow();
+  });
+
+  it("emits slots from the correct rule for each date period " +
+    "(Jun Tuesdays get 10am–4pm, Jul Tuesdays get 12pm–4pm)", () => {
+    const rA = rule(2, 10, 16, 60, 0, NYC, dt(NYC, 2025, 1, 1, 0), dt(NYC, 2025, 6, 30, 23, 59));
+    const rB = rule(2, 12, 16, 60, 0, NYC, dt(NYC, 2025, 7, 1, 0), dt(NYC, 2025, 12, 31, 23, 59));
+
+    const slots = generateSlots({
+      rules: [rA, rB],
+      busy: [],
+      window: win,
+      providerZone: NYC,
+      renderZone: NYC,
+    });
+
+    // Jun Tuesdays (2025-06-03, 2025-06-10, 2025-06-17, 2025-06-24): 6 slots each = 24
+    // Jul Tuesdays (2025-07-01, 2025-07-08, 2025-07-15, 2025-07-22, 2025-07-29): 4 slots each = 20
+    const junTuesdaySlots = slots.filter((s) => {
+      const local = s.startUtc.setZone(NYC);
+      return local.month === 6 && local.weekday === 2;
+    });
+    const julTuesdaySlots = slots.filter((s) => {
+      const local = s.startUtc.setZone(NYC);
+      return local.month === 7 && local.weekday === 2;
+    });
+
+    // Jun rule: 10am–4pm, 60-min slots → 6 slots per Tuesday
+    expect(junTuesdaySlots.length).toBe(4 * 6); // 4 Jun Tuesdays × 6 slots
+
+    // Jul rule: 12pm–4pm, 60-min slots → 4 slots per Tuesday
+    expect(julTuesdaySlots.length).toBe(5 * 4); // 5 Jul Tuesdays × 4 slots
+
+    // Jun slots should NOT start before 10am local
+    for (const s of junTuesdaySlots) {
+      const local = s.startUtc.setZone(NYC);
+      expect(local.hour).toBeGreaterThanOrEqual(10);
+    }
+
+    // Jul slots should NOT start before 12pm local
+    for (const s of julTuesdaySlots) {
+      const local = s.startUtc.setZone(NYC);
+      expect(local.hour).toBeGreaterThanOrEqual(12);
+    }
+  });
+
+  it("STILL throws for same weekday + overlapping time windows + overlapping date ranges", () => {
+    // Both rules active for the same date range — conflict
+    const rA = rule(2, 10, 16, 60, 0, NYC, dt(NYC, 2025, 6, 1, 0), dt(NYC, 2025, 8, 31, 23, 59));
+    const rB = rule(2, 12, 18, 60, 0, NYC, dt(NYC, 2025, 7, 1, 0), dt(NYC, 2025, 9, 30, 23, 59));
 
     expect(() =>
       generateSlots({
@@ -1353,23 +1311,20 @@ describe("validateRules — date-bounded rule overlap", () => {
     ).toThrow();
   });
 
-  it(
-    "does NOT throw for same weekday + non-overlapping time windows + overlapping date ranges " +
-      "(regression: existing adjacent-rule behaviour)",
-    () => {
-      // Both active all year, but time windows don't overlap (morning vs afternoon)
-      const rMorning = rule(2, 9, 12, 60, 0, NYC);
-      const rAfternoon = rule(2, 14, 17, 60, 0, NYC); // gap 12–14, no overlap
+  it("does NOT throw for same weekday + non-overlapping time windows + overlapping date ranges " +
+    "(regression: existing adjacent-rule behaviour)", () => {
+    // Both active all year, but time windows don't overlap (morning vs afternoon)
+    const rMorning = rule(2, 9, 12, 60, 0, NYC);
+    const rAfternoon = rule(2, 14, 17, 60, 0, NYC); // gap 12–14, no overlap
 
-      expect(() =>
-        generateSlots({
-          rules: [rMorning, rAfternoon],
-          busy: [],
-          window: win,
-          providerZone: NYC,
-          renderZone: NYC,
-        }),
-      ).not.toThrow();
-    },
-  );
+    expect(() =>
+      generateSlots({
+        rules: [rMorning, rAfternoon],
+        busy: [],
+        window: win,
+        providerZone: NYC,
+        renderZone: NYC,
+      }),
+    ).not.toThrow();
+  });
 });

--- a/tests/unit/slot-gen.test.ts
+++ b/tests/unit/slot-gen.test.ts
@@ -1167,3 +1167,209 @@ describe("Fixture: overlapping availability rules throw", () => {
     ).not.toThrow();
   });
 });
+
+// ---------------------------------------------------------------------------
+// Fixture: validateRules — date-bounded overlap
+// ---------------------------------------------------------------------------
+
+describe("validateRules — date-bounded rule overlap", () => {
+  const NYC = "America/New_York";
+
+  // Window spanning Jun + Jul 2025 (covers both date-bounded rules)
+  const win = {
+    startUtc: DateTime.fromISO("2025-06-01T00:00:00Z"),
+    endUtc: DateTime.fromISO("2025-08-01T00:00:00Z"),
+  };
+
+  it(
+    "does NOT throw for same weekday + overlapping time windows + non-overlapping date ranges " +
+      "(SPEC §Availability rule semantics: 'normal Tuesdays 10–4 except July when 12–4')",
+    () => {
+      // Rule A: Tuesdays 10am–4pm, effective Jan 1–Jun 30
+      const rA = rule(
+        2, // Tuesday
+        10,
+        16,
+        60,
+        0,
+        NYC,
+        dt(NYC, 2025, 1, 1, 0),
+        dt(NYC, 2025, 6, 30, 23, 59),
+      );
+      // Rule B: Tuesdays 12pm–4pm, effective Jul 1–Dec 31
+      // Time windows overlap (12–16 is inside 10–16), but date ranges do not.
+      const rB = rule(
+        2, // Tuesday
+        12,
+        16,
+        60,
+        0,
+        NYC,
+        dt(NYC, 2025, 7, 1, 0),
+        dt(NYC, 2025, 12, 31, 23, 59),
+      );
+
+      expect(() =>
+        generateSlots({
+          rules: [rA, rB],
+          busy: [],
+          window: win,
+          providerZone: NYC,
+          renderZone: NYC,
+        }),
+      ).not.toThrow();
+    },
+  );
+
+  it(
+    "emits slots from the correct rule for each date period " +
+      "(Jun Tuesdays get 10am–4pm, Jul Tuesdays get 12pm–4pm)",
+    () => {
+      const rA = rule(
+        2,
+        10,
+        16,
+        60,
+        0,
+        NYC,
+        dt(NYC, 2025, 1, 1, 0),
+        dt(NYC, 2025, 6, 30, 23, 59),
+      );
+      const rB = rule(
+        2,
+        12,
+        16,
+        60,
+        0,
+        NYC,
+        dt(NYC, 2025, 7, 1, 0),
+        dt(NYC, 2025, 12, 31, 23, 59),
+      );
+
+      const slots = generateSlots({
+        rules: [rA, rB],
+        busy: [],
+        window: win,
+        providerZone: NYC,
+        renderZone: NYC,
+      });
+
+      // Jun Tuesdays (2025-06-03, 2025-06-10, 2025-06-17, 2025-06-24): 6 slots each = 24
+      // Jul Tuesdays (2025-07-01, 2025-07-08, 2025-07-15, 2025-07-22, 2025-07-29): 4 slots each = 20
+      const junTuesdaySlots = slots.filter((s) => {
+        const local = s.startUtc.setZone(NYC);
+        return local.month === 6 && local.weekday === 2;
+      });
+      const julTuesdaySlots = slots.filter((s) => {
+        const local = s.startUtc.setZone(NYC);
+        return local.month === 7 && local.weekday === 2;
+      });
+
+      // Jun rule: 10am–4pm, 60-min slots → 6 slots per Tuesday
+      expect(junTuesdaySlots.length).toBe(4 * 6); // 4 Jun Tuesdays × 6 slots
+
+      // Jul rule: 12pm–4pm, 60-min slots → 4 slots per Tuesday
+      expect(julTuesdaySlots.length).toBe(5 * 4); // 5 Jul Tuesdays × 4 slots
+
+      // Jun slots should NOT start before 10am local
+      for (const s of junTuesdaySlots) {
+        const local = s.startUtc.setZone(NYC);
+        expect(local.hour).toBeGreaterThanOrEqual(10);
+      }
+
+      // Jul slots should NOT start before 12pm local
+      for (const s of julTuesdaySlots) {
+        const local = s.startUtc.setZone(NYC);
+        expect(local.hour).toBeGreaterThanOrEqual(12);
+      }
+    },
+  );
+
+  it("STILL throws for same weekday + overlapping time windows + overlapping date ranges", () => {
+    // Both rules active for the same date range — conflict
+    const rA = rule(
+      2,
+      10,
+      16,
+      60,
+      0,
+      NYC,
+      dt(NYC, 2025, 6, 1, 0),
+      dt(NYC, 2025, 8, 31, 23, 59),
+    );
+    const rB = rule(
+      2,
+      12,
+      18,
+      60,
+      0,
+      NYC,
+      dt(NYC, 2025, 7, 1, 0),
+      dt(NYC, 2025, 9, 30, 23, 59),
+    );
+
+    expect(() =>
+      generateSlots({
+        rules: [rA, rB],
+        busy: [],
+        window: win,
+        providerZone: NYC,
+        renderZone: NYC,
+      }),
+    ).toThrow();
+  });
+
+  it("throws when one bounded + one unbounded rule have overlapping time windows", () => {
+    // Unbounded rule covers ALL dates, so it overlaps with the bounded rule's period.
+    const rBounded = rule(
+      2,
+      10,
+      16,
+      60,
+      0,
+      NYC,
+      dt(NYC, 2025, 6, 1, 0),
+      dt(NYC, 2025, 6, 30, 23, 59),
+    );
+    const rUnbounded = rule(
+      2,
+      12,
+      18,
+      60,
+      0,
+      NYC,
+      undefined, // valid_from = null → -infinity
+      undefined, // valid_to = null → +infinity
+    );
+
+    expect(() =>
+      generateSlots({
+        rules: [rBounded, rUnbounded],
+        busy: [],
+        window: win,
+        providerZone: NYC,
+        renderZone: NYC,
+      }),
+    ).toThrow();
+  });
+
+  it(
+    "does NOT throw for same weekday + non-overlapping time windows + overlapping date ranges " +
+      "(regression: existing adjacent-rule behaviour)",
+    () => {
+      // Both active all year, but time windows don't overlap (morning vs afternoon)
+      const rMorning = rule(2, 9, 12, 60, 0, NYC);
+      const rAfternoon = rule(2, 14, 17, 60, 0, NYC); // gap 12–14, no overlap
+
+      expect(() =>
+        generateSlots({
+          rules: [rMorning, rAfternoon],
+          busy: [],
+          window: win,
+          providerZone: NYC,
+          renderZone: NYC,
+        }),
+      ).not.toThrow();
+    },
+  );
+});


### PR DESCRIPTION
Closes #7

## Summary

- `packages/core/src/slot-gen.ts`: `generateSlots()` pure function — no I/O, no `Date.now()`, Luxon-only DST math
- `packages/core/index.ts`: re-exports the public API
- `tests/unit/slot-gen.test.ts`: 8 property-based invariants (200 cases each via fast-check v4) + 9 fixture groups

**Commit history is test-first**: commit `9370422` adds all tests in red (module missing); commit `159fa2c` adds the implementation that turns them green.

## Implementation notes

**Buffer semantics** (applied AFTER session only):
```ts
// why: v0.1 decision — pre-buffer rejected for rule-model simplicity;
// grid = slot_minutes + buffer_minutes. Revisit in v0.2 if requested.
```

**DST gap detection**: `DateTime.fromObject({zone})` in a spring-forward gap silently advances the clock. We detect this by comparing requested `hour/minute` to the returned `hour/minute`. Mismatch → slot omitted.

**Fall-back fold deduplication**: grid-based iteration visits each local wall-clock time once. The `seenUtcMillis` Set guards against any double-emit. Luxon defaults to the pre-fold (EDT) instant on `fromObject` in ambiguous fold times.

**Overlap validation**: two rules throw if `a.start_local < b.end_local && b.start_local < a.end_local` — strict inequalities so adjacent (touching) rules are permitted.

## Test plan

### Property invariants (200 cases each)

| # | Property | Status |
|---|----------|--------|
| 1 | Every emitted slot fully inside `window` | ✅ pass |
| 2 | Every slot disjoint from every `busy` block (touching OK) | ✅ pass |
| 3 | Slot starts align to `(slot+buffer)` grid relative to `start_local` | ✅ pass |
| 4 | Slot count non-increasing in `|busy|` | ✅ pass |
| 5 | Slot list identical regardless of `renderZone` | ✅ pass |
| 6 | No slot starts inside a DST gap in `providerZone` | ✅ pass |
| 7 | Fall-back fold: exactly one slot per UTC instant (no duplicate wall-clock) | ✅ pass |
| 8 | Two overlapping rules same weekday → throws | ✅ pass |

### Fixed-case fixtures

| Fixture | Status |
|---------|--------|
| US DST spring-forward Mar 9 2025 — gap slots omitted, 14 slots counted | ✅ pass |
| US DST spring-forward Mar 8 2026 — gap slots omitted, 14 slots counted | ✅ pass |
| US DST fall-back Nov 2 2025 — 1am fold offered exactly once | ✅ pass |
| Madrid provider + NYC booker Mar 8–29 2026 (US DST started, EU not) | ✅ pass |
| EU DST start Mar 29 2026 — Madrid 2am gap slot omitted | ✅ pass |
| Leap day Feb 29 2024 — 8 slots, correct date/zone | ✅ pass |
| Year boundary Dec 31 2025 → Jan 1 2026 — 8 slots across boundary | ✅ pass |
| ISO week boundary Sun Jan 5 → Mon Jan 6 2025 — 4 slots | ✅ pass |
| `Pacific/Apia` — no crash, all slots valid | ✅ pass |
| Maya 50/10 buffer → 60-min grid, 6 slots/day Tue+Thu LA | ✅ pass |
| Overlapping rules → throws; adjacent rules → does not throw | ✅ pass |

### Full `bun test` output

```
bun test v1.3.11

-------------------------------|---------|---------|-------------------
File                           | % Funcs | % Lines | Uncovered Line #s
-------------------------------|---------|---------|-------------------
All files                      |  100.00 |  100.00 |
 packages/core/src/slot-gen.ts |  100.00 |  100.00 |
-------------------------------|---------|---------|-------------------

 21 pass
 0 fail
 93 expect() calls
Ran 21 tests across 1 file. [988ms]

# Full suite (all packages):
 27 pass
 0 fail
 99 expect() calls
Ran 27 tests across 7 files. [917ms]
```

`bun run typecheck` — clean
`bun run lint` — clean (Biome, no errors)

## Reviewer

Integrations track (#8 author) — please reproduce via `bun test tests/unit/slot-gen.test.ts` and post evidence.

https://claude.ai/code/session_01VS1pxnCA4d6mHKDFcejm6T

---
_Generated by [Claude Code](https://claude.ai/code/session_01VS1pxnCA4d6mHKDFcejm6T)_