### PR TITLE
feat(worker): Google one-way push worker (Sprint 1 Track B, #20)

### DIFF
--- a/apps/worker/index.test.ts
+++ b/apps/worker/index.test.ts
@@ -1,9 +1,92 @@
-import { describe, expect, it } from "bun:test";
+// apps/worker/index.test.ts
+//
+// TDD test: the worker must call pgque.ticker(queue_name) once per poll cycle,
+// BEFORE calling pgque.next_batch.  Without the ticker the pgque.tick table
+// never advances and next_batch always returns NULL.
+//
+// This is a unit test — no real Postgres required.  We exercise the exported
+// `processBatch` function by injecting a mock DB client.
 
-// Trivial harness test — proves bun test runs in @calendry/worker.
-// Real job handler tests land in Sprint 1.
-describe("@calendry/worker scaffold", () => {
-  it("test harness is functional", () => {
-    expect(true).toBe(true);
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+import type { Client } from "pg";
+
+// Re-import after we wire up the injectable db — we test the exported helper
+// directly rather than the full main() to avoid port/connect side-effects.
+import { processBatch } from "./src/index";
+
+// ---------------------------------------------------------------------------
+// Mock DB client factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a minimal mock pg.Client that records every query() call.
+ * next_batch returns NULL (empty queue) — enough to prove ticker was called.
+ */
+function makeDbMock(): { db: Client; calls: Array<{ text: string; values: unknown[] }> } {
+  const calls: Array<{ text: string; values: unknown[] }> = [];
+
+  const db = {
+    query: mock(async (text: string, values?: unknown[]) => {
+      calls.push({ text, values: values ?? [] });
+
+      // pgque.ticker — return a tick id (or NULL if no new events; both are fine)
+      if (text.includes("pgque.ticker")) {
+        return { rows: [{ ticker: 1n }], rowCount: 1 };
+      }
+      // pgque.next_batch — return NULL (empty queue)
+      if (text.includes("pgque.next_batch")) {
+        return { rows: [{ next_batch: null }], rowCount: 1 };
+      }
+      return { rows: [], rowCount: 0 };
+    }),
+  } as unknown as Client;
+
+  return { db, calls };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("processBatch — self-tick requirement", () => {
+  it("calls pgque.ticker before pgque.next_batch on each poll cycle", async () => {
+    const { db, calls } = makeDbMock();
+
+    await processBatch(db);
+
+    // ticker must have been called
+    const tickerCall = calls.find((c) => c.text.includes("pgque.ticker"));
+    expect(tickerCall).toBeDefined();
+
+    // next_batch must have been called
+    const nextBatchCall = calls.find((c) => c.text.includes("pgque.next_batch"));
+    expect(nextBatchCall).toBeDefined();
+
+    // ticker must come BEFORE next_batch in call order
+    const tickerIdx = calls.indexOf(tickerCall!);
+    const nextBatchIdx = calls.indexOf(nextBatchCall!);
+    expect(tickerIdx).toBeLessThan(nextBatchIdx);
+  });
+
+  it("calls pgque.ticker exactly once per processBatch invocation", async () => {
+    const { db, calls } = makeDbMock();
+
+    await processBatch(db);
+
+    const tickerCalls = calls.filter((c) => c.text.includes("pgque.ticker"));
+    expect(tickerCalls).toHaveLength(1);
+  });
+
+  it("passes QUEUE_NAME to pgque.ticker", async () => {
+    const { db, calls } = makeDbMock();
+
+    await processBatch(db);
+
+    const tickerCall = calls.find((c) => c.text.includes("pgque.ticker"));
+    // The queue name must appear in either the SQL text or the bound params
+    const hasQueueName =
+      tickerCall?.text.includes("google_push") ||
+      tickerCall?.values.includes("google_push");
+    expect(hasQueueName).toBe(true);
   });
 });

--- a/apps/worker/index.test.ts
+++ b/apps/worker/index.test.ts
@@ -63,7 +63,9 @@ describe("processBatch — self-tick requirement", () => {
     expect(nextBatchCall).toBeDefined();
 
     // ticker must come BEFORE next_batch in call order
+    // biome-ignore lint/style/noNonNullAssertion: tickerCall and nextBatchCall were asserted defined above
     const tickerIdx = calls.indexOf(tickerCall!);
+    // biome-ignore lint/style/noNonNullAssertion: same as above
     const nextBatchIdx = calls.indexOf(nextBatchCall!);
     expect(tickerIdx).toBeLessThan(nextBatchIdx);
   });
@@ -85,8 +87,7 @@ describe("processBatch — self-tick requirement", () => {
     const tickerCall = calls.find((c) => c.text.includes("pgque.ticker"));
     // The queue name must appear in either the SQL text or the bound params
     const hasQueueName =
-      tickerCall?.text.includes("google_push") ||
-      tickerCall?.values.includes("google_push");
+      tickerCall?.text.includes("google_push") || tickerCall?.values.includes("google_push");
     expect(hasQueueName).toBe(true);
   });
 });

--- a/apps/worker/src/fixture-fetch.ts
+++ b/apps/worker/src/fixture-fetch.ts
@@ -1,0 +1,84 @@
+// apps/worker/src/fixture-fetch.ts
+//
+// Fixture-replay fetch for dev/test when GOOGLE_REFRESH_TOKEN is unset.
+// Returns responses from packages/google/fixtures/ based on request URL and
+// body content, replicating the Google API and OAuth token endpoint behaviours
+// documented in ERRORS.md.
+//
+// This is the local-first amendment from .samo/SPEC.amendments.md:
+//   "dev/test must work without real Google credentials"
+
+import errorInvalidGrant from "../../../packages/google/fixtures/error-invalid-grant.json";
+import happyPathInsert from "../../../packages/google/fixtures/happy-path-insert.json";
+import happyPathList from "../../../packages/google/fixtures/happy-path-list.json";
+import happyPathToken from "../../../packages/google/fixtures/happy-path-token.json";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+/**
+ * A fetch implementation that replays fixture JSON without hitting Google.
+ *
+ * Route table:
+ *   POST https://oauth2.googleapis.com/token  → happy-path-token (200)
+ *   POST .../events?requestId=...             → happy-path-insert (200)
+ *   GET  .../events?...                       → happy-path-list (200)
+ *   all other                                 → 404 with an explanatory message
+ */
+export async function fixtureFetch(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+): Promise<Response> {
+  const url = input.toString();
+
+  // OAuth token exchange
+  if (url.includes("oauth2.googleapis.com/token")) {
+    const body = init?.body?.toString() ?? "";
+    if (body.includes("invalid") || body.includes("revoked")) {
+      return jsonResponse(errorInvalidGrant, 400);
+    }
+    return jsonResponse(happyPathToken, 200);
+  }
+
+  // Google Calendar API — events.insert (POST with requestId)
+  if (url.includes("/events") && init?.method === "POST" && url.includes("requestId")) {
+    return jsonResponse(happyPathInsert, 200);
+  }
+
+  // Google Calendar API — events.list (GET)
+  if (url.includes("/events") && (!init?.method || init.method === "GET")) {
+    return jsonResponse(happyPathList, 200);
+  }
+
+  // Google Calendar API — events.delete (DELETE)
+  if (url.includes("/events/") && init?.method === "DELETE") {
+    return new Response(null, { status: 204 });
+  }
+
+  // Google Calendar API — events.patch (PATCH)
+  if (url.includes("/events/") && init?.method === "PATCH") {
+    return jsonResponse(happyPathInsert, 200);
+  }
+
+  // Google Calendar API — events.watch (POST /events/watch)
+  if (url.includes("/events/watch") && init?.method === "POST") {
+    return jsonResponse(
+      {
+        kind: "api#channel",
+        id: "fixture-channel-id",
+        resourceId: "fixture-resource-id",
+        expiration: String(Date.now() + 7 * 24 * 60 * 60 * 1000),
+      },
+      200,
+    );
+  }
+
+  return new Response(JSON.stringify({ error: `fixture-fetch: no fixture for ${url}` }), {
+    status: 404,
+    headers: { "Content-Type": "application/json" },
+  });
+}

--- a/apps/worker/src/google-push.test.ts
+++ b/apps/worker/src/google-push.test.ts
@@ -1,0 +1,470 @@
+// apps/worker/src/google-push.test.ts
+//
+// TDD tests for the google_push job handler.
+// Per CLAUDE.md and SPEC §Idempotency: idempotency is on the strict-TDD list.
+// All tests use fixture-replay fetch — no real Google credentials required.
+
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import type { Client } from "pg";
+import { processGooglePushJob } from "./google-push";
+import type { GooglePushJobPayload } from "./google-push";
+
+// ---------------------------------------------------------------------------
+// Fixture JSON (loaded from packages/google/fixtures/)
+// ---------------------------------------------------------------------------
+
+import happyPathInsert from "../../../packages/google/fixtures/happy-path-insert.json";
+import happyPathToken from "../../../packages/google/fixtures/happy-path-token.json";
+import error409WithEvent from "../../../packages/google/fixtures/error-409-with-event.json";
+import error409Duplicate from "../../../packages/google/fixtures/error-409-duplicate.json";
+import errorInvalidGrant from "../../../packages/google/fixtures/error-invalid-grant.json";
+import error5xxRetryAfter from "../../../packages/google/fixtures/error-5xx-retry-after.json";
+import happyPathList from "../../../packages/google/fixtures/happy-path-list.json";
+import errorRepeated401 from "../../../packages/google/fixtures/error-repeated-401.json";
+
+// ---------------------------------------------------------------------------
+// Test data
+// ---------------------------------------------------------------------------
+
+const PROVIDER_ID = "11111111-1111-1111-1111-111111111111";
+const BOOKING_ID = "22222222-2222-2222-2222-222222222222";
+const IDEMPOTENCY_KEY = "test-idempotency-key-001";
+
+const PROVIDER_ROW = {
+  id: PROVIDER_ID,
+  email: "provider@example.com",
+  home_tz: "Europe/Madrid",
+  google_oauth_refresh_token: "test-refresh-token",
+  oauth_status: "connected",
+};
+
+const BOOKING_ROW = {
+  id: BOOKING_ID,
+  provider_id: PROVIDER_ID,
+  booker_email: "booker@example.com",
+  booker_name: "Test Booker",
+  booker_notes: null,
+  start_utc: new Date("2026-05-10T12:00:00Z"),
+  end_utc: new Date("2026-05-10T12:50:00Z"),
+  state: "pending_push",
+  google_event_id: null,
+  idempotency_key: IDEMPOTENCY_KEY,
+};
+
+const JOB_PAYLOAD: GooglePushJobPayload = { booking_id: BOOKING_ID };
+
+// ---------------------------------------------------------------------------
+// Helpers: make Response-like objects from fixtures
+// ---------------------------------------------------------------------------
+
+function makeResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function makeResponseWithHeader(
+  body: unknown,
+  status: number,
+  headers: Record<string, string>,
+): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json", ...headers },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// DB client mock factory
+// ---------------------------------------------------------------------------
+
+function makeDbClient(overrides?: {
+  bookingRow?: Record<string, unknown> | null;
+  providerRow?: Record<string, unknown> | null;
+  updateCallback?: (text: string, values: unknown[]) => void;
+}): Client {
+  const bookingRow = overrides?.bookingRow !== undefined ? overrides.bookingRow : BOOKING_ROW;
+  const providerRow = overrides?.providerRow !== undefined ? overrides.providerRow : PROVIDER_ROW;
+  const updateCallback = overrides?.updateCallback;
+
+  const queryMock = mock(async (text: string, values?: unknown[]) => {
+    if (text.includes("select") && text.includes("bookings") && text.includes("providers")) {
+      // JOIN query for booking + provider
+      if (bookingRow === null || providerRow === null) {
+        return { rows: [], rowCount: 0 };
+      }
+      return {
+        rows: [{ ...bookingRow, ...providerRow }],
+        rowCount: 1,
+      };
+    }
+    if (text.includes("update") && text.includes("bookings") && updateCallback) {
+      updateCallback(text, values ?? []);
+    }
+    if (text.includes("update") && text.includes("providers") && updateCallback) {
+      updateCallback(text, values ?? []);
+    }
+    if (text.includes("insert") && text.includes("email_outbox") && updateCallback) {
+      updateCallback(text, values ?? []);
+    }
+    return { rows: [], rowCount: 1 };
+  });
+
+  return {
+    query: queryMock,
+    // biome-ignore lint/suspicious/noExplicitAny: test mock shape
+  } as any as Client;
+}
+
+// ---------------------------------------------------------------------------
+// 1. Happy-path test: booking pushed, state → confirmed, google_event_id set
+// ---------------------------------------------------------------------------
+
+describe("processGooglePushJob — happy path", () => {
+  it("transitions booking to confirmed and stores google_event_id", async () => {
+    const updatedFields: Array<{ sql: string; values: unknown[] }> = [];
+
+    const db = makeDbClient({
+      updateCallback: (sql, values) => {
+        updatedFields.push({ sql, values });
+      },
+    });
+
+    // fetch sequence: token exchange → events.insert
+    let callCount = 0;
+    const fetchImpl = mock(async (_url: string, _init?: RequestInit) => {
+      callCount++;
+      if (callCount === 1) {
+        // token exchange
+        return makeResponse(happyPathToken, 200);
+      }
+      // events.insert
+      return makeResponse(happyPathInsert, 200);
+    });
+
+    await processGooglePushJob({ db, fetchImpl, payload: JOB_PAYLOAD });
+
+    // Expect two DB updates: one for state+google_event_id, no others
+    const bookingUpdate = updatedFields.find(
+      (f) => f.sql.includes("update") && f.sql.includes("bookings"),
+    );
+    expect(bookingUpdate).toBeDefined();
+    // state should be 'confirmed'
+    expect(bookingUpdate?.values).toContain("confirmed");
+    // google_event_id should be the fixture event id
+    expect(bookingUpdate?.values).toContain("fixture_event_id_001");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Idempotency test: calling twice MUST NOT create two Google events
+// ---------------------------------------------------------------------------
+
+describe("processGooglePushJob — idempotency (strict TDD requirement)", () => {
+  it("second call sees 409 path and reconciles, does NOT create a second event", async () => {
+    const updatedFields: Array<{ sql: string; values: unknown[] }> = [];
+
+    // Second call: booking is already confirmed + has google_event_id
+    const alreadyConfirmedBooking = {
+      ...BOOKING_ROW,
+      state: "confirmed",
+      google_event_id: "fixture_event_id_001",
+    };
+
+    const db = makeDbClient({
+      bookingRow: alreadyConfirmedBooking,
+      updateCallback: (sql, values) => {
+        updatedFields.push({ sql, values });
+      },
+    });
+
+    let insertCallCount = 0;
+    const fetchImpl = mock(async (url: string, _init?: RequestInit) => {
+      if (url.includes("oauth2.googleapis.com")) {
+        return makeResponse(happyPathToken, 200);
+      }
+      if (url.includes("/events") && !url.includes("syncToken")) {
+        insertCallCount++;
+        // Return 409 with the existing event embedded
+        return makeResponse(error409WithEvent, 409);
+      }
+      return makeResponse(happyPathList, 200);
+    });
+
+    await processGooglePushJob({ db, fetchImpl, payload: JOB_PAYLOAD });
+
+    // Should NOT have made more than zero insert attempts (booking already confirmed)
+    // OR should have called reconcile409 — either way, no second event created.
+    // The key invariant: google_event_id stays fixture_event_id_001, not a new one.
+    const bookingUpdates = updatedFields.filter(
+      (f) => f.sql.includes("update") && f.sql.includes("bookings"),
+    );
+
+    // If it did update, the event id must be the existing one, not a new one
+    for (const upd of bookingUpdates) {
+      if (upd.values.includes("confirmed")) {
+        expect(upd.values).toContain("fixture_event_id_001");
+      }
+    }
+  });
+
+  it("409 path: reconcile409 extracts event id from 409 body", async () => {
+    const updatedFields: Array<{ sql: string; values: unknown[] }> = [];
+
+    const db = makeDbClient({
+      updateCallback: (sql, values) => {
+        updatedFields.push({ sql, values });
+      },
+    });
+
+    // fetch: token OK, then 409 with event embedded in body
+    let callCount = 0;
+    const fetchImpl = mock(async (url: string, _init?: RequestInit) => {
+      callCount++;
+      if (url.includes("oauth2.googleapis.com")) {
+        return makeResponse(happyPathToken, 200);
+      }
+      return makeResponse(error409WithEvent, 409);
+    });
+
+    await processGooglePushJob({ db, fetchImpl, payload: JOB_PAYLOAD });
+
+    const bookingUpdate = updatedFields.find(
+      (f) =>
+        f.sql.includes("update") &&
+        f.sql.includes("bookings") &&
+        f.values.includes("confirmed"),
+    );
+    expect(bookingUpdate).toBeDefined();
+    // Must store the event id from the 409 body
+    expect(bookingUpdate?.values).toContain("fixture_event_id_001");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. 5xx retry test: 5 consecutive 503s → GoogleApiError thrown (job fails)
+// ---------------------------------------------------------------------------
+
+describe("processGooglePushJob — 5xx retry exhaustion", () => {
+  it("nacks job after 5 consecutive 503 responses", async () => {
+    const db = makeDbClient();
+
+    let callCount = 0;
+    const fetchImpl = mock(async (url: string, _init?: RequestInit) => {
+      if (url.includes("oauth2.googleapis.com")) {
+        return makeResponse(happyPathToken, 200);
+      }
+      callCount++;
+      // Return 503 with Retry-After: 0 so tests don't sleep
+      return makeResponseWithHeader(error5xxRetryAfter, 503, { "Retry-After": "0" });
+    });
+
+    await expect(
+      processGooglePushJob({ db, fetchImpl, payload: JOB_PAYLOAD }),
+    ).rejects.toThrow();
+
+    // All 5 attempts exhausted (calendarClient retries internally)
+    expect(callCount).toBe(5);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. OAuth revoked test: invalid_grant → provider marked revoked, email enqueued
+// ---------------------------------------------------------------------------
+
+describe("processGooglePushJob — OAuth revoked (invalid_grant)", () => {
+  it("marks provider oauth_status=revoked and writes email_outbox row", async () => {
+    const dbCalls: Array<{ sql: string; values: unknown[] }> = [];
+
+    const db = makeDbClient({
+      updateCallback: (sql, values) => {
+        dbCalls.push({ sql, values });
+      },
+    });
+
+    // fetch: token exchange returns invalid_grant
+    const fetchImpl = mock(async (url: string, _init?: RequestInit) => {
+      if (url.includes("oauth2.googleapis.com")) {
+        return makeResponse(errorInvalidGrant, 400);
+      }
+      return makeResponse(happyPathInsert, 200);
+    });
+
+    await expect(
+      processGooglePushJob({ db, fetchImpl, payload: JOB_PAYLOAD }),
+    ).rejects.toThrow();
+
+    // Provider oauth_status must be set to 'revoked'
+    const providerUpdate = dbCalls.find(
+      (c) => c.sql.includes("update") && c.sql.includes("providers"),
+    );
+    expect(providerUpdate).toBeDefined();
+    expect(providerUpdate?.values).toContain("revoked");
+
+    // email_outbox row must be inserted for the provider
+    const emailInsert = dbCalls.find(
+      (c) => c.sql.includes("insert") && c.sql.includes("email_outbox"),
+    );
+    expect(emailInsert).toBeDefined();
+  });
+
+  it("marks provider revoked on repeated 401 (OAuthTokenExpiredError)", async () => {
+    const dbCalls: Array<{ sql: string; values: unknown[] }> = [];
+
+    const db = makeDbClient({
+      updateCallback: (sql, values) => {
+        dbCalls.push({ sql, values });
+      },
+    });
+
+    // Token exchange succeeds but calendar API returns 401 twice
+    const fetchImpl = mock(async (url: string, _init?: RequestInit) => {
+      if (url.includes("oauth2.googleapis.com")) {
+        return makeResponse(happyPathToken, 200);
+      }
+      // Both insert attempts return 401
+      return makeResponse(errorRepeated401, 401);
+    });
+
+    await expect(
+      processGooglePushJob({ db, fetchImpl, payload: JOB_PAYLOAD }),
+    ).rejects.toThrow();
+
+    const providerUpdate = dbCalls.find(
+      (c) => c.sql.includes("update") && c.sql.includes("providers"),
+    );
+    expect(providerUpdate).toBeDefined();
+    expect(providerUpdate?.values).toContain("revoked");
+
+    const emailInsert = dbCalls.find(
+      (c) => c.sql.includes("insert") && c.sql.includes("email_outbox"),
+    );
+    expect(emailInsert).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. Paused provider test: worker skips jobs for degraded/revoked providers
+// ---------------------------------------------------------------------------
+
+describe("processGooglePushJob — paused provider skip", () => {
+  it("skips job without calling Google when provider is degraded", async () => {
+    let googleCallCount = 0;
+
+    const db = makeDbClient({
+      providerRow: { ...PROVIDER_ROW, oauth_status: "degraded" },
+    });
+
+    const fetchImpl = mock(async (url: string, _init?: RequestInit) => {
+      if (!url.includes("oauth2.googleapis.com")) {
+        googleCallCount++;
+      }
+      return makeResponse(happyPathToken, 200);
+    });
+
+    // Should NOT throw — it skips cleanly
+    await processGooglePushJob({ db, fetchImpl, payload: JOB_PAYLOAD });
+
+    // No Google Calendar API calls
+    expect(googleCallCount).toBe(0);
+  });
+
+  it("skips job without calling Google when provider is revoked", async () => {
+    let googleCallCount = 0;
+
+    const db = makeDbClient({
+      providerRow: { ...PROVIDER_ROW, oauth_status: "revoked" },
+    });
+
+    const fetchImpl = mock(async (url: string, _init?: RequestInit) => {
+      if (!url.includes("oauth2.googleapis.com")) {
+        googleCallCount++;
+      }
+      return makeResponse(happyPathToken, 200);
+    });
+
+    await processGooglePushJob({ db, fetchImpl, payload: JOB_PAYLOAD });
+
+    expect(googleCallCount).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. Missing booking: gracefully handle booking not found
+// ---------------------------------------------------------------------------
+
+describe("processGooglePushJob — booking not found", () => {
+  it("throws when booking row does not exist", async () => {
+    const db = makeDbClient({ bookingRow: null });
+
+    const fetchImpl = mock(async () => makeResponse(happyPathToken, 200));
+
+    await expect(
+      processGooglePushJob({ db, fetchImpl, payload: JOB_PAYLOAD }),
+    ).rejects.toThrow(/booking.*not found/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 7. Scope downgrade: OAuthScopeDowngradeError → provider marked revoked
+// ---------------------------------------------------------------------------
+
+describe("processGooglePushJob — OAuth scope downgrade", () => {
+  it("marks provider revoked on scope downgrade", async () => {
+    const dbCalls: Array<{ sql: string; values: unknown[] }> = [];
+
+    const db = makeDbClient({
+      updateCallback: (sql, values) => {
+        dbCalls.push({ sql, values });
+      },
+    });
+
+    // Token succeeds but missing the calendar scope
+    const fetchImpl = mock(async (url: string, _init?: RequestInit) => {
+      if (url.includes("oauth2.googleapis.com")) {
+        return makeResponse(
+          {
+            access_token: "ya29.limited",
+            expires_in: 3599,
+            scope: "https://www.googleapis.com/auth/userinfo.email",
+            token_type: "Bearer",
+          },
+          200,
+        );
+      }
+      return makeResponse(happyPathInsert, 200);
+    });
+
+    await expect(
+      processGooglePushJob({ db, fetchImpl, payload: JOB_PAYLOAD }),
+    ).rejects.toThrow();
+
+    const providerUpdate = dbCalls.find(
+      (c) => c.sql.includes("update") && c.sql.includes("providers"),
+    );
+    expect(providerUpdate).toBeDefined();
+    expect(providerUpdate?.values).toContain("revoked");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 8. 410 from insert (edge case): log and fail once
+// ---------------------------------------------------------------------------
+
+describe("processGooglePushJob — 410 edge case", () => {
+  it("throws SyncTokenExpiredError when Google returns 410 on insert", async () => {
+    const db = makeDbClient();
+
+    const fetchImpl = mock(async (url: string, _init?: RequestInit) => {
+      if (url.includes("oauth2.googleapis.com")) {
+        return makeResponse(happyPathToken, 200);
+      }
+      return makeResponse({ error: { code: 410, message: "Gone" } }, 410);
+    });
+
+    await expect(
+      processGooglePushJob({ db, fetchImpl, payload: JOB_PAYLOAD }),
+    ).rejects.toThrow(/410|sync.token/i);
+  });
+});

--- a/apps/worker/src/google-push.test.ts
+++ b/apps/worker/src/google-push.test.ts
@@ -13,14 +13,14 @@ import type { GooglePushJobPayload } from "./google-push";
 // Fixture JSON (loaded from packages/google/fixtures/)
 // ---------------------------------------------------------------------------
 
-import happyPathInsert from "../../../packages/google/fixtures/happy-path-insert.json";
-import happyPathToken from "../../../packages/google/fixtures/happy-path-token.json";
-import error409WithEvent from "../../../packages/google/fixtures/error-409-with-event.json";
-import error409Duplicate from "../../../packages/google/fixtures/error-409-duplicate.json";
-import errorInvalidGrant from "../../../packages/google/fixtures/error-invalid-grant.json";
 import error5xxRetryAfter from "../../../packages/google/fixtures/error-5xx-retry-after.json";
-import happyPathList from "../../../packages/google/fixtures/happy-path-list.json";
+import error409Duplicate from "../../../packages/google/fixtures/error-409-duplicate.json";
+import error409WithEvent from "../../../packages/google/fixtures/error-409-with-event.json";
+import errorInvalidGrant from "../../../packages/google/fixtures/error-invalid-grant.json";
 import errorRepeated401 from "../../../packages/google/fixtures/error-repeated-401.json";
+import happyPathInsert from "../../../packages/google/fixtures/happy-path-insert.json";
+import happyPathList from "../../../packages/google/fixtures/happy-path-list.json";
+import happyPathToken from "../../../packages/google/fixtures/happy-path-token.json";
 
 // ---------------------------------------------------------------------------
 // Test data
@@ -79,6 +79,33 @@ function makeResponseWithHeader(
 // DB client mock factory
 // ---------------------------------------------------------------------------
 
+// The JOIN query aliases provider columns with p_ prefix. Build the combined
+// row shape that matches what the SQL SELECT actually returns.
+function makeJoinedRow(
+  bookingRow: Record<string, unknown>,
+  providerRow: Record<string, unknown>,
+): Record<string, unknown> {
+  return {
+    // booking columns (unaliased)
+    id: bookingRow.id,
+    provider_id: bookingRow.provider_id,
+    booker_email: bookingRow.booker_email,
+    booker_name: bookingRow.booker_name,
+    booker_notes: bookingRow.booker_notes ?? null,
+    start_utc: bookingRow.start_utc,
+    end_utc: bookingRow.end_utc,
+    state: bookingRow.state,
+    google_event_id: bookingRow.google_event_id ?? null,
+    idempotency_key: bookingRow.idempotency_key,
+    // provider columns (p_ alias)
+    p_id: providerRow.id,
+    p_email: providerRow.email,
+    p_home_tz: providerRow.home_tz,
+    p_google_oauth_refresh_token: providerRow.google_oauth_refresh_token ?? null,
+    p_oauth_status: providerRow.oauth_status,
+  };
+}
+
 function makeDbClient(overrides?: {
   bookingRow?: Record<string, unknown> | null;
   providerRow?: Record<string, unknown> | null;
@@ -95,7 +122,7 @@ function makeDbClient(overrides?: {
         return { rows: [], rowCount: 0 };
       }
       return {
-        rows: [{ ...bookingRow, ...providerRow }],
+        rows: [makeJoinedRow(bookingRow, providerRow)],
         rowCount: 1,
       };
     }
@@ -232,9 +259,7 @@ describe("processGooglePushJob — idempotency (strict TDD requirement)", () => 
 
     const bookingUpdate = updatedFields.find(
       (f) =>
-        f.sql.includes("update") &&
-        f.sql.includes("bookings") &&
-        f.values.includes("confirmed"),
+        f.sql.includes("update") && f.sql.includes("bookings") && f.values.includes("confirmed"),
     );
     expect(bookingUpdate).toBeDefined();
     // Must store the event id from the 409 body
@@ -260,9 +285,7 @@ describe("processGooglePushJob — 5xx retry exhaustion", () => {
       return makeResponseWithHeader(error5xxRetryAfter, 503, { "Retry-After": "0" });
     });
 
-    await expect(
-      processGooglePushJob({ db, fetchImpl, payload: JOB_PAYLOAD }),
-    ).rejects.toThrow();
+    await expect(processGooglePushJob({ db, fetchImpl, payload: JOB_PAYLOAD })).rejects.toThrow();
 
     // All 5 attempts exhausted (calendarClient retries internally)
     expect(callCount).toBe(5);
@@ -291,9 +314,7 @@ describe("processGooglePushJob — OAuth revoked (invalid_grant)", () => {
       return makeResponse(happyPathInsert, 200);
     });
 
-    await expect(
-      processGooglePushJob({ db, fetchImpl, payload: JOB_PAYLOAD }),
-    ).rejects.toThrow();
+    await expect(processGooglePushJob({ db, fetchImpl, payload: JOB_PAYLOAD })).rejects.toThrow();
 
     // Provider oauth_status must be set to 'revoked'
     const providerUpdate = dbCalls.find(
@@ -327,9 +348,7 @@ describe("processGooglePushJob — OAuth revoked (invalid_grant)", () => {
       return makeResponse(errorRepeated401, 401);
     });
 
-    await expect(
-      processGooglePushJob({ db, fetchImpl, payload: JOB_PAYLOAD }),
-    ).rejects.toThrow();
+    await expect(processGooglePushJob({ db, fetchImpl, payload: JOB_PAYLOAD })).rejects.toThrow();
 
     const providerUpdate = dbCalls.find(
       (c) => c.sql.includes("update") && c.sql.includes("providers"),
@@ -400,9 +419,9 @@ describe("processGooglePushJob — booking not found", () => {
 
     const fetchImpl = mock(async () => makeResponse(happyPathToken, 200));
 
-    await expect(
-      processGooglePushJob({ db, fetchImpl, payload: JOB_PAYLOAD }),
-    ).rejects.toThrow(/booking.*not found/i);
+    await expect(processGooglePushJob({ db, fetchImpl, payload: JOB_PAYLOAD })).rejects.toThrow(
+      /booking.*not found/i,
+    );
   });
 });
 
@@ -436,9 +455,7 @@ describe("processGooglePushJob — OAuth scope downgrade", () => {
       return makeResponse(happyPathInsert, 200);
     });
 
-    await expect(
-      processGooglePushJob({ db, fetchImpl, payload: JOB_PAYLOAD }),
-    ).rejects.toThrow();
+    await expect(processGooglePushJob({ db, fetchImpl, payload: JOB_PAYLOAD })).rejects.toThrow();
 
     const providerUpdate = dbCalls.find(
       (c) => c.sql.includes("update") && c.sql.includes("providers"),
@@ -463,8 +480,8 @@ describe("processGooglePushJob — 410 edge case", () => {
       return makeResponse({ error: { code: 410, message: "Gone" } }, 410);
     });
 
-    await expect(
-      processGooglePushJob({ db, fetchImpl, payload: JOB_PAYLOAD }),
-    ).rejects.toThrow(/410|sync.token/i);
+    await expect(processGooglePushJob({ db, fetchImpl, payload: JOB_PAYLOAD })).rejects.toThrow(
+      /410|sync.token/i,
+    );
   });
 });

--- a/apps/worker/src/google-push.ts
+++ b/apps/worker/src/google-push.ts
@@ -1,0 +1,257 @@
+// apps/worker/src/google-push.ts
+//
+// Handler for the google_push pgque job.
+// Consumes { booking_id } payloads — loads booking + provider, calls
+// events.insert via @calendry/google, and transitions booking state to
+// confirmed on success.
+//
+// Error handling per SPEC §Data flow / booking creation step 4:
+//   - 200: booking.state = confirmed, google_event_id stored
+//   - 409 dup: reconcile409 (CalendarClient handles this internally)
+//   - 5xx / 429: GoogleApiError thrown → caller nacks for exponential backoff
+//   - OAuthInvalidGrantError / OAuthTokenExpiredError / OAuthScopeDowngradeError:
+//       providers.oauth_status = 'revoked', email_outbox row inserted, rethrow
+//   - 410 (SyncTokenExpiredError): log + rethrow (fail once, not relevant for push)
+//   - degraded/revoked provider: skip job cleanly (return without error)
+
+import type { Client } from "pg";
+import {
+  CalendarClient,
+  OAuthInvalidGrantError,
+  OAuthScopeDowngradeError,
+  OAuthTokenExpiredError,
+  exchangeRefreshToken,
+} from "../../../packages/google/index";
+import type { EventResource } from "../../../packages/google/index";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface GooglePushJobPayload {
+  booking_id: string;
+}
+
+export interface ProcessGooglePushOptions {
+  db: Client;
+  payload: GooglePushJobPayload;
+  /** Injectable fetch — defaults to globalThis.fetch. Pass a fixture-replay
+   *  fetch for testing. When GOOGLE_REFRESH_TOKEN is unset the worker startup
+   *  injects the fixture-replay fetch automatically. */
+  fetchImpl?: typeof globalThis.fetch;
+}
+
+interface BookingWithProvider {
+  // booking columns
+  id: string;
+  provider_id: string;
+  booker_email: string;
+  booker_name: string;
+  booker_notes: string | null;
+  start_utc: Date;
+  end_utc: Date;
+  state: string;
+  google_event_id: string | null;
+  idempotency_key: string;
+  // provider columns (aliased with p_ prefix)
+  p_id: string;
+  p_email: string;
+  p_home_tz: string;
+  p_google_oauth_refresh_token: string | null;
+  p_oauth_status: string;
+}
+
+// ---------------------------------------------------------------------------
+// OAuth failure helper
+// ---------------------------------------------------------------------------
+
+/**
+ * On OAuth auth failure: mark provider revoked, insert email_outbox row,
+ * then re-throw the original error so the pgque batch is nacked.
+ */
+async function handleOAuthFailure(
+  db: Client,
+  providerId: string,
+  providerEmail: string,
+  bookingId: string,
+  originalError: Error,
+): Promise<never> {
+  // Mark provider revoked
+  await db.query(
+    `update providers
+        set oauth_status = $1, updated_at = now()
+      where id = $2`,
+    ["revoked", providerId],
+  );
+
+  // Write email_outbox row so the provider is notified
+  // idempotency_key = provider_id:oauth_revoked — deduped if the job retried
+  await db.query(
+    `insert into email_outbox
+       (booking_id, kind, recipient_email, send_after, idempotency_key)
+     values ($1, 'conflict_notification', $2, now(), $3)
+     on conflict (idempotency_key) do nothing`,
+    [bookingId, providerEmail, `${providerId}:oauth_revoked`],
+  );
+
+  throw originalError;
+}
+
+// ---------------------------------------------------------------------------
+// Core handler
+// ---------------------------------------------------------------------------
+
+/**
+ * Process a single google_push job.
+ *
+ * This function is pure in the sense that all side-effects (DB, Google API)
+ * are injected. The pgque poll loop calls it; on success it returns void; on
+ * transient error it throws (so the caller can nack + schedule retry); on
+ * permanent OAuth failure it writes the degradation row + throws.
+ */
+export async function processGooglePushJob(options: ProcessGooglePushOptions): Promise<void> {
+  const { db, payload, fetchImpl = globalThis.fetch } = options;
+  const { booking_id } = payload;
+
+  // ------------------------------------------------------------------
+  // 1. Load booking + provider in one query (avoids two round-trips)
+  // ------------------------------------------------------------------
+  const result = await db.query<BookingWithProvider>(
+    `select
+       b.id,
+       b.provider_id,
+       b.booker_email,
+       b.booker_name,
+       b.booker_notes,
+       b.start_utc,
+       b.end_utc,
+       b.state,
+       b.google_event_id,
+       b.idempotency_key,
+       p.id          as p_id,
+       p.email       as p_email,
+       p.home_tz     as p_home_tz,
+       p.google_oauth_refresh_token as p_google_oauth_refresh_token,
+       p.oauth_status as p_oauth_status
+     from bookings b
+     join providers p on p.id = b.provider_id
+     where b.id = $1`,
+    [booking_id],
+  );
+
+  if (result.rows.length === 0) {
+    throw new Error(`google_push: booking ${booking_id} not found`);
+  }
+
+  const row = result.rows[0];
+
+  // ------------------------------------------------------------------
+  // 2. Skip if provider is paused (degraded or revoked)
+  //    Per SPEC: "pause the queue for that provider — do not nack indefinitely"
+  // ------------------------------------------------------------------
+  if (row.p_oauth_status === "degraded" || row.p_oauth_status === "revoked") {
+    console.warn(
+      `google_push: skipping booking ${booking_id} — provider ${row.p_id} oauth_status=${row.p_oauth_status}`,
+    );
+    return;
+  }
+
+  // ------------------------------------------------------------------
+  // 3. Skip if already confirmed (idempotency guard at the DB level)
+  //    The calendarClient also handles 409 internally, but this avoids
+  //    a redundant Google API call entirely on the second attempt.
+  // ------------------------------------------------------------------
+  if (row.state === "confirmed" && row.google_event_id !== null) {
+    console.info(
+      `google_push: booking ${booking_id} already confirmed with event ${row.google_event_id}, skipping`,
+    );
+    return;
+  }
+
+  // ------------------------------------------------------------------
+  // 4. Refresh access token
+  // ------------------------------------------------------------------
+  if (!row.p_google_oauth_refresh_token) {
+    throw new Error(`google_push: provider ${row.p_id} has no refresh token`);
+  }
+
+  let accessToken: string;
+  try {
+    const tokenResult = await exchangeRefreshToken(
+      {
+        clientId: process.env.GOOGLE_CLIENT_ID ?? "fixture-client-id",
+        clientSecret: process.env.GOOGLE_CLIENT_SECRET ?? "fixture-client-secret",
+        refreshToken: row.p_google_oauth_refresh_token,
+      },
+      fetchImpl,
+    );
+    accessToken = tokenResult.accessToken;
+  } catch (err) {
+    if (err instanceof OAuthInvalidGrantError || err instanceof OAuthScopeDowngradeError) {
+      return handleOAuthFailure(db, row.p_id, row.p_email, booking_id, err as Error);
+    }
+    throw err;
+  }
+
+  // ------------------------------------------------------------------
+  // 5. Build CalendarClient + call events.insert
+  // ------------------------------------------------------------------
+  const client = new CalendarClient({
+    accessToken,
+    calendarId: "primary",
+    fetch: fetchImpl,
+  });
+
+  // HTML-escape booker_name (SPEC §Security: "HTML-escape booker_name everywhere rendered")
+  const safeName = row.booker_name
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+
+  const resource: EventResource = {
+    summary: `Booking: ${safeName}`,
+    description: row.booker_notes
+      ? row.booker_notes.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
+      : undefined,
+    start: {
+      dateTime: row.start_utc.toISOString(),
+      timeZone: row.p_home_tz,
+    },
+    end: {
+      dateTime: row.end_utc.toISOString(),
+      timeZone: row.p_home_tz,
+    },
+    attendees: [{ email: row.booker_email }],
+  };
+
+  // requestId = idempotency_key + ":push" per SPEC §Idempotency
+  const requestId = `${row.idempotency_key}:push`;
+
+  let event: Awaited<ReturnType<CalendarClient["insert"]>>;
+  try {
+    event = await client.insert({ requestId, resource });
+  } catch (err) {
+    if (err instanceof OAuthTokenExpiredError) {
+      // Two consecutive 401s — token is truly gone
+      return handleOAuthFailure(db, row.p_id, row.p_email, booking_id, err as Error);
+    }
+    // GoogleApiError (5xx/429 exhausted), SyncTokenExpiredError, or anything
+    // else — re-throw so the pgque batch gets nacked and retried.
+    throw err;
+  }
+
+  // ------------------------------------------------------------------
+  // 6. Update booking: state = confirmed, google_event_id = event.id
+  // ------------------------------------------------------------------
+  await db.query(
+    `update bookings
+        set state           = $1,
+            google_event_id = $2,
+            updated_at      = now()
+      where id = $3`,
+    ["confirmed", event.id, booking_id],
+  );
+
+  console.info(`google_push: booking ${booking_id} confirmed → google event ${event.id}`);
+}

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -1,0 +1,198 @@
+// apps/worker/src/index.ts
+//
+// Calendry worker process — pgque consumers.
+//
+// Job classes wired in Sprint 1:
+//   google_push  — create Google Calendar events for pending bookings
+//
+// Sprint 2+ will add: sync_pull, email_send, safety_resync, channel_renewal.
+//
+// Startup banner explains fixture-replay mode:
+//   When GOOGLE_REFRESH_TOKEN is unset (dev/test), the worker uses a
+//   fixture-replay fetch that returns canned JSON from
+//   packages/google/fixtures/. Set GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET,
+//   and GOOGLE_REFRESH_TOKEN for production mode.
+//
+// pgque consumer pattern (direct SQL, no ORM, no framework — per CLAUDE.md):
+//   1. pgque.create_queue('google_push')   — idempotent, safe on restart
+//   2. pgque.register_consumer(queue, name) — idempotent
+//   3. Loop: pgque.next_batch → pgque.get_batch_events → process →
+//            pgque.event_retry (nack) or pgque.finish_batch (ack)
+//   4. LISTEN pgque_google_push for immediate wakeup on new events
+
+import { Client } from "pg";
+import { fixtureFetch } from "./fixture-fetch";
+import { processGooglePushJob } from "./google-push";
+import type { GooglePushJobPayload } from "./google-push";
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+const QUEUE_NAME = "google_push";
+const CONSUMER_NAME = "worker-google-push-1";
+const POLL_INTERVAL_MS = 5_000;
+
+// Exponential backoff delays (seconds) for retries 0..4.
+// On attempt N (0-indexed), delay = 2^N seconds → 1, 2, 4, 8, 16.
+const RETRY_DELAYS_SECONDS = [1, 2, 4, 8, 16] as const;
+
+// ---------------------------------------------------------------------------
+// Banner
+// ---------------------------------------------------------------------------
+
+const fixtureMode = !process.env.GOOGLE_REFRESH_TOKEN;
+// Cast fixtureFetch to the global fetch type — it satisfies the fetch contract
+// (same signature for request/response), just lacks non-standard properties like
+// `preconnect` that TypeScript adds to `typeof globalThis.fetch`.
+const fetchImpl = (fixtureMode ? fixtureFetch : globalThis.fetch) as typeof globalThis.fetch;
+
+console.log("╔══════════════════════════════════════════════╗");
+console.log("║        Calendry Worker — google_push         ║");
+console.log("╚══════════════════════════════════════════════╝");
+if (fixtureMode) {
+  console.log(
+    "⚠  FIXTURE-REPLAY MODE: GOOGLE_REFRESH_TOKEN is unset.\n" +
+      "   Google API calls return canned JSON from packages/google/fixtures/.\n" +
+      "   Set GOOGLE_CLIENT_ID + GOOGLE_CLIENT_SECRET + GOOGLE_REFRESH_TOKEN\n" +
+      "   for production mode.",
+  );
+} else {
+  console.log("Production mode: using real Google credentials.");
+}
+
+// ---------------------------------------------------------------------------
+// DB connection
+// ---------------------------------------------------------------------------
+
+const db = new Client({
+  connectionString:
+    process.env.DATABASE_URL ?? "postgresql://postgres:postgres@localhost:5432/postgres",
+});
+
+// ---------------------------------------------------------------------------
+// Startup: ensure queue exists + register consumer
+// ---------------------------------------------------------------------------
+
+async function ensureQueueAndConsumer(): Promise<void> {
+  // pgque.create_queue returns 0 if already exists, 1 if created — idempotent.
+  await db.query("select pgque.create_queue($1)", [QUEUE_NAME]);
+  console.log(`Queue '${QUEUE_NAME}' ensured.`);
+
+  // pgque.register_consumer returns 0 if already registered — idempotent.
+  await db.query("select pgque.register_consumer($1, $2)", [QUEUE_NAME, CONSUMER_NAME]);
+  console.log(`Consumer '${CONSUMER_NAME}' registered on '${QUEUE_NAME}'.`);
+}
+
+// ---------------------------------------------------------------------------
+// Poll loop
+// ---------------------------------------------------------------------------
+
+/**
+ * Process one pgque batch for the google_push queue.
+ * Returns true if a batch was found and processed, false if the queue was empty.
+ */
+async function processBatch(): Promise<boolean> {
+  // next_batch returns NULL when there are no events.
+  const batchResult = await db.query<{ next_batch: string | null }>(
+    "select pgque.next_batch($1, $2) as next_batch",
+    [QUEUE_NAME, CONSUMER_NAME],
+  );
+  const batchId = batchResult.rows[0]?.next_batch ?? null;
+  if (batchId === null) {
+    return false; // nothing to do
+  }
+
+  // Fetch all events in this batch.
+  const eventsResult = await db.query<{
+    ev_id: string;
+    ev_data: string;
+    ev_retry: number | null;
+  }>("select ev_id, ev_data, ev_retry from pgque.get_batch_events($1)", [batchId]);
+
+  for (const ev of eventsResult.rows) {
+    const payload = JSON.parse(ev.ev_data) as GooglePushJobPayload;
+    const attemptNumber = (ev.ev_retry ?? 0) + 1; // ev_retry is null on first attempt
+
+    try {
+      await processGooglePushJob({ db, payload, fetchImpl });
+      // Success: ack this individual event (not the whole batch yet)
+    } catch (err) {
+      const errMsg = err instanceof Error ? err.message : String(err);
+      console.error(`google_push: job ${ev.ev_id} failed (attempt ${attemptNumber}): ${errMsg}`);
+
+      if (attemptNumber >= 5) {
+        // Exhausted all 5 attempts — log as fatal, do NOT retry further.
+        console.error(
+          `google_push: job ${ev.ev_id} permanently failed after ${attemptNumber} attempts — dropping`,
+        );
+        // Fall through: finish_batch will mark it done without retry.
+      } else {
+        // Nack with exponential backoff.
+        const delaySec = RETRY_DELAYS_SECONDS[attemptNumber - 1] ?? 16;
+        await db.query("select pgque.event_retry($1, $2, $3)", [batchId, ev.ev_id, delaySec]);
+      }
+    }
+  }
+
+  // Finish the batch (mark subscription advanced past this tick).
+  await db.query("select pgque.finish_batch($1)", [batchId]);
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  await db.connect();
+  console.log("Connected to Postgres.");
+
+  await ensureQueueAndConsumer();
+
+  // LISTEN for pgque wakeup notifications — avoids busy-polling.
+  await db.query(`listen pgque_${QUEUE_NAME}`);
+  console.log(`Listening on channel pgque_${QUEUE_NAME}`);
+
+  // Process any events already in the queue before entering the event loop.
+  let drained = false;
+  while (!drained) {
+    drained = !(await processBatch());
+  }
+
+  console.log(`Polling for ${QUEUE_NAME} jobs (interval ${POLL_INTERVAL_MS}ms) …`);
+
+  // Event loop: wake on NOTIFY or fall back to polling.
+  db.on("notification", async (msg) => {
+    if (msg.channel === `pgque_${QUEUE_NAME}`) {
+      await processBatch();
+    }
+  });
+
+  // Safety poll — handles the window between LISTEN and any missed NOTIFYs.
+  setInterval(async () => {
+    try {
+      await processBatch();
+    } catch (err) {
+      console.error("google_push: poll error:", err);
+    }
+  }, POLL_INTERVAL_MS);
+
+  // Keep the process alive.
+  process.on("SIGTERM", async () => {
+    console.log("SIGTERM received — shutting down.");
+    await db.end();
+    process.exit(0);
+  });
+
+  process.on("SIGINT", async () => {
+    console.log("SIGINT received — shutting down.");
+    await db.end();
+    process.exit(0);
+  });
+}
+
+main().catch((err) => {
+  console.error("Worker fatal error:", err);
+  process.exit(1);
+});

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -16,9 +16,14 @@
 // pgque consumer pattern (direct SQL, no ORM, no framework — per CLAUDE.md):
 //   1. pgque.create_queue('google_push')   — idempotent, safe on restart
 //   2. pgque.register_consumer(queue, name) — idempotent
-//   3. Loop: pgque.next_batch → pgque.get_batch_events → process →
-//            pgque.event_retry (nack) or pgque.finish_batch (ack)
+//   3. Loop: pgque.ticker(queue_name) → pgque.next_batch → pgque.get_batch_events
+//            → process → pgque.event_retry (nack) or pgque.finish_batch (ack)
 //   4. LISTEN pgque_google_push for immediate wakeup on new events
+//
+// Self-ticking:
+//   why: Self-ticking worker — works without pg_cron. For production scale,
+//        schedule pg_cron to call pgque.ticker(queue_id) every Ns and remove
+//        this self-tick. Documented in docs/self-host.md.
 
 import { Client } from "pg";
 import { fixtureFetch } from "./fixture-fetch";
@@ -79,6 +84,14 @@ async function ensureQueueAndConsumer(): Promise<void> {
   await db.query("select pgque.create_queue($1)", [QUEUE_NAME]);
   console.log(`Queue '${QUEUE_NAME}' ensured.`);
 
+  // Log queue_id for easier debugging (e.g., when wiring pg_cron manually).
+  const queueIdResult = await db.query<{ queue_id: number }>(
+    "select queue_id from pgque.queue where queue_name = $1",
+    [QUEUE_NAME],
+  );
+  const queueId = queueIdResult.rows[0]?.queue_id ?? "(not found)";
+  console.log(`Queue '${QUEUE_NAME}' queue_id=${queueId}.`);
+
   // pgque.register_consumer returns 0 if already registered — idempotent.
   await db.query("select pgque.register_consumer($1, $2)", [QUEUE_NAME, CONSUMER_NAME]);
   console.log(`Consumer '${CONSUMER_NAME}' registered on '${QUEUE_NAME}'.`);
@@ -91,10 +104,17 @@ async function ensureQueueAndConsumer(): Promise<void> {
 /**
  * Process one pgque batch for the google_push queue.
  * Returns true if a batch was found and processed, false if the queue was empty.
+ *
+ * Exported so the unit test can inject a mock db client and assert ticker is called.
  */
-async function processBatch(): Promise<boolean> {
+export async function processBatch(dbClient: typeof db = db): Promise<boolean> {
+  // why: Self-ticking worker — works without pg_cron. For production scale,
+  //      schedule pg_cron to call pgque.ticker(queue_id) every Ns and remove
+  //      this self-tick. Documented in docs/self-host.md.
+  await dbClient.query("select pgque.ticker($1)", [QUEUE_NAME]);
+
   // next_batch returns NULL when there are no events.
-  const batchResult = await db.query<{ next_batch: string | null }>(
+  const batchResult = await dbClient.query<{ next_batch: string | null }>(
     "select pgque.next_batch($1, $2) as next_batch",
     [QUEUE_NAME, CONSUMER_NAME],
   );
@@ -104,7 +124,7 @@ async function processBatch(): Promise<boolean> {
   }
 
   // Fetch all events in this batch.
-  const eventsResult = await db.query<{
+  const eventsResult = await dbClient.query<{
     ev_id: string;
     ev_data: string;
     ev_retry: number | null;
@@ -115,7 +135,7 @@ async function processBatch(): Promise<boolean> {
     const attemptNumber = (ev.ev_retry ?? 0) + 1; // ev_retry is null on first attempt
 
     try {
-      await processGooglePushJob({ db, payload, fetchImpl });
+      await processGooglePushJob({ db: dbClient, payload, fetchImpl });
       // Success: ack this individual event (not the whole batch yet)
     } catch (err) {
       const errMsg = err instanceof Error ? err.message : String(err);
@@ -129,14 +149,20 @@ async function processBatch(): Promise<boolean> {
         // Fall through: finish_batch will mark it done without retry.
       } else {
         // Nack with exponential backoff.
+        // Cast $3 to integer explicitly — pgque has two event_retry overloads
+        // (integer seconds vs. timestamptz) and PG can't infer the type otherwise.
         const delaySec = RETRY_DELAYS_SECONDS[attemptNumber - 1] ?? 16;
-        await db.query("select pgque.event_retry($1, $2, $3)", [batchId, ev.ev_id, delaySec]);
+        await dbClient.query("select pgque.event_retry($1::bigint, $2::bigint, $3::integer)", [
+          batchId,
+          ev.ev_id,
+          delaySec,
+        ]);
       }
     }
   }
 
   // Finish the batch (mark subscription advanced past this tick).
-  await db.query("select pgque.finish_batch($1)", [batchId]);
+  await dbClient.query("select pgque.finish_batch($1)", [batchId]);
   return true;
 }
 
@@ -192,7 +218,11 @@ async function main(): Promise<void> {
   });
 }
 
-main().catch((err) => {
-  console.error("Worker fatal error:", err);
-  process.exit(1);
-});
+// Only run main when executed directly (not when imported by tests).
+// why: import.meta.main is Bun's equivalent of Node's require.main === module.
+if (import.meta.main) {
+  main().catch((err) => {
+    console.error("Worker fatal error:", err);
+    process.exit(1);
+  });
+}

--- a/docs/self-host.md
+++ b/docs/self-host.md
@@ -63,6 +63,7 @@ _TODO (Sprint 3): Expand with troubleshooting steps for common migration failure
 - Verify every change was applied cleanly: `sqlever verify --plan db/sqitch.plan`
 - Revert path (roll back all): `sqlever revert --plan db/sqitch.plan` — scripts in `db/revert/` mirror each deploy script.
 - pgque schema: the `pgque` migration step (`db/deploy/pgque.sql`) loads the vendored `db/pgque.sql`; confirm the `pgque` schema exists after deploy: `psql $DATABASE_URL -c '\dn'`.
+- **pgque ticker:** by default the worker self-ticks (`pgque.ticker(queue_name)`) on every poll cycle — no extra setup required; for production scale, offload the tick to pg_cron instead: `SELECT cron.schedule('pgque-google-push-tick', '5 seconds', $$SELECT pgque.ticker('google_push')$$);` and the self-tick in the worker can then be removed.
 
 ---
 


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Implements the `google_push` pgque worker (Sprint 1 / Track B, issue #20)
- `processGooglePushJob()` consumes `{ booking_id }` payloads: loads booking + provider, calls `events.insert`, transitions `pending_push → confirmed`
- Full OAuth failure handling: `invalid_grant`, scope downgrade, repeated 401 → `providers.oauth_status = 'revoked'` + `email_outbox` notification row
- 5 retry attempts with exponential backoff (1s / 2s / 4s / 8s / 16s) via `pgque.event_retry`
- Fixture-replay fetch auto-injected when `GOOGLE_REFRESH_TOKEN` is unset; startup banner makes this explicit
- Queue creation (`pgque.create_queue`) and consumer registration (`pgque.register_consumer`) are idempotent at startup

## Checklist (per CLAUDE.md PR workflow)

- [x] Branch off `main`: `feat/20-google-push-worker`
- [x] All 4 required TDD tests green (idempotency, 5xx retry, OAuth revoked, 409 reconcile)
- [x] Total: 127 unit tests pass, 0 fail (`bun test`)
- [x] `bun run typecheck` — clean (pre-existing web/db errors unrelated to this PR are the same as on `main`)
- [x] `bun run lint` — clean (biome check passes)
- [x] Conventional Commits: `test:` commit before `feat:` commit (red/green TDD history preserved)
- [x] Fixture-replay fetch documented in startup banner and code comments
- [x] HTML-escaping of `booker_name` and `booker_notes` per SPEC §Security
- [x] `idempotency_key + ":push"` as Google `requestId` per SPEC §Idempotency
- [x] Provider skip (no infinite nack) for `degraded`/`revoked` oauth_status
- [x] `email_outbox` row written on OAuth failure (idempotent: `on conflict do nothing`)

## Files changed

| File | Role |
|---|---|
| `apps/worker/src/google-push.ts` | Core job handler (`processGooglePushJob`) |
| `apps/worker/src/fixture-fetch.ts` | Fixture-replay fetch for dev/test |
| `apps/worker/src/index.ts` | pgque poll loop, startup, SIGTERM handler |
| `apps/worker/src/google-push.test.ts` | 11 TDD tests (red commit first, then green) |

## Test evidence

```
bun test apps/worker/src/google-push.test.ts
 11 pass
 0 fail
 22 expect() calls
Ran 11 tests across 1 file.

bun test (full suite)
 127 pass
 0 fail
 314 expect() calls
Ran 127 tests across 14 files.
```

## Deviations from issue spec

None. All 4 required TDD tests pass. Fixture-replay mode implemented and documented. `pgque.create_queue` called at startup as required. `providers.oauth_status` set to `'revoked'` (not `'degraded'`) on permanent OAuth failure per ERRORS.md taxonomy ("mark provider degraded" means revoked-level — the column constraint allows `connected | degraded | revoked`; on `invalid_grant` we write `revoked` as the most severe / accurate state).

## Reviewer

Track A (Backend / Scheduling) — manager will dispatch.

https://github.com/NikolayS/calendry2/issues/20
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VS1pxnCA4d6mHKDFcejm6T)_