### PR TITLE
ops: align docker-compose env var names with code (regression from #23)

### DIFF
--- a/ops/docker-compose.yml
+++ b/ops/docker-compose.yml
@@ -198,7 +198,7 @@ services:
       NEXT_PUBLIC_SUPABASE_ANON_KEY: ${NEXT_PUBLIC_SUPABASE_ANON_KEY:-}
       DATABASE_URL: ${DATABASE_URL:-postgresql://postgres:postgres@postgres:5432/postgres}
       CSRF_SECRET: ${CSRF_SECRET:-changeme}
-      SIGNED_LINK_SECRET: ${SIGNED_LINK_SECRET:-changeme}
+      BOOKING_TOKEN_SECRET: ${BOOKING_TOKEN_SECRET:-changeme}
       RESEND_API_KEY: ${RESEND_API_KEY:-}
       EMAIL_FROM: ${EMAIL_FROM:-noreply@example.com}
       EMAIL_DRIVER: ${EMAIL_DRIVER:-smtp}
@@ -206,8 +206,8 @@ services:
       SMTP_PORT: ${SMTP_PORT:-1025}
       GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID:-}
       GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET:-}
-      RATE_LIMIT_PER_IP: ${RATE_LIMIT_PER_IP:-10}
-      RATE_LIMIT_PER_EMAIL: ${RATE_LIMIT_PER_EMAIL:-3}
+      RATE_LIMIT_BOOKING_IP_PER_MIN: ${RATE_LIMIT_BOOKING_IP_PER_MIN:-10}
+      RATE_LIMIT_BOOKING_EMAIL_PER_MIN: ${RATE_LIMIT_BOOKING_EMAIL_PER_MIN:-3}
       # Internal GoTrue URL — web calls this server-side to proxy magic-link requests
       GOTRUE_URL: http://gotrue:9999
     ports:
@@ -236,7 +236,7 @@ services:
       SMTP_PORT: ${SMTP_PORT:-1025}
       GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID:-}
       GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET:-}
-      SIGNED_LINK_SECRET: ${SIGNED_LINK_SECRET:-changeme}
+      BOOKING_TOKEN_SECRET: ${BOOKING_TOKEN_SECRET:-changeme}
       NEXT_PUBLIC_URL: ${NEXT_PUBLIC_URL:-http://localhost:3000}
     depends_on:
       postgres:


### PR DESCRIPTION
## Summary

- Fixes a regression introduced by #23, which renamed env vars in code and `.env.example` but left `ops/docker-compose.yml` using the old names.
- Caught by REV review on #24: https://github.com/NikolayS/calendry2/pull/24#issuecomment-4363420958
- Only `ops/docker-compose.yml` is changed — applied to both `web` and `worker` services.

## Renames applied (both `web` and `worker`)

| Old name (compose) | New name (code + `.env.example`) |
|---|---|
| `SIGNED_LINK_SECRET` | `BOOKING_TOKEN_SECRET` |
| `RATE_LIMIT_PER_IP` | `RATE_LIMIT_BOOKING_IP_PER_MIN` |
| `RATE_LIMIT_PER_EMAIL` | `RATE_LIMIT_BOOKING_EMAIL_PER_MIN` |

## Verification output

```
$ docker compose -f ops/docker-compose.yml config | grep -E 'BOOKING_TOKEN_SECRET|RATE_LIMIT_BOOKING_'
      BOOKING_TOKEN_SECRET: changeme
      RATE_LIMIT_BOOKING_EMAIL_PER_MIN: "3"
      RATE_LIMIT_BOOKING_IP_PER_MIN: "10"
      BOOKING_TOKEN_SECRET: changeme
```

Old names (`SIGNED_LINK_SECRET`, `RATE_LIMIT_PER_IP`, `RATE_LIMIT_PER_EMAIL`) no longer appear in `docker compose config` output.

```
$ bun install --frozen-lockfile   # no changes
$ bun run test                    # 116 pass, 0 fail
$ bun run typecheck               # clean
$ bun run lint                    # no fixes applied
```

https://claude.ai/code/session_01VS1pxnCA4d6mHKDFcejm6T

---
_Generated by [Claude Code](https://claude.ai/code/session_01VS1pxnCA4d6mHKDFcejm6T)_